### PR TITLE
Require at least C11 and C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,10 @@ endif()
 
 project("Red Eclipse Legacy" C CXX)
 
+# require at least C++14 and C11
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(src)


### PR DESCRIPTION
Right now we don't require some standards explicitly. Let's change that! We want to be able to use more modern features.