### PR TITLE
Fix bug where chat symbol wasn't shown on dominated/dominating people

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3205,16 +3205,22 @@ namespace game
                 if(d->conopen) t = textureload(hud::chattex, 3);
                 else if(m_team(gamemode, mutators) && (hud::numteamkills() >= teamkillwarn || aboveheadteam&(d->team != focus->team ? 2 : 1)))
                     t = textureload(hud::teamtexname(d->team), 3);
-                if((!m_team(gamemode, mutators) || d->team != focus->team) && (!d->conopen)) // only display the dominating/dominated icon if the player isn't chatting atm
+                if(!m_team(gamemode, mutators) || d->team != focus->team)
                 {
                     if(d->dominating.find(focus) >= 0)
                     {
-                        t = textureload(hud::dominatingtex, 3);
+                    	if (!d->conopen) // if the player is chatting chat the symbol will pulsate
+                    	{
+                        	t = textureload(hud::dominatingtex, 3);
+                    	}
                         colour = pulsecols[PULSE_DISCO][clamp((lastmillis/100)%PULSECOLOURS, 0, PULSECOLOURS-1)];
                     }
                     else if(d->dominated.find(focus) >= 0)
                     {
-                        t = textureload(hud::dominatedtex, 3);
+                    	if (!d->conopen) // if the player is chatting the chat symbol will pulsate
+                    	{
+                    		t = textureload(hud::dominatedtex, 3);
+                    	}
                         colour = pulsecols[PULSE_DISCO][clamp((lastmillis/100)%PULSECOLOURS, 0, PULSECOLOURS-1)];
                     }
                 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3205,7 +3205,7 @@ namespace game
                 if(d->conopen) t = textureload(hud::chattex, 3);
                 else if(m_team(gamemode, mutators) && (hud::numteamkills() >= teamkillwarn || aboveheadteam&(d->team != focus->team ? 2 : 1)))
                     t = textureload(hud::teamtexname(d->team), 3);
-                if(!m_team(gamemode, mutators) || d->team != focus->team)
+                if((!m_team(gamemode, mutators) || d->team != focus->team) && (!d->conopen)) // only display the dominating/dominated icon if the player isn't chatting atm
                 {
                     if(d->dominating.find(focus) >= 0)
                     {


### PR DESCRIPTION
There was a bug where when you were dominating someone and they were chatting you wouldn't see the chat symbol above their head but only the dominating symbol, I fixed this by only showing the dominating/dominated symbol while you're not chatting