### PR TITLE
Fix resetcontrols duplicate bug

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1682,23 +1682,6 @@ advanced_sound_options = [
         ]
     ]
 ]
-new_ui resetcontrols [
-    ui_header "Reset Controls"
-    ui_font "emphasis" [ ui_center [ ui_text "RESTORE DEFAULT CONTROLS" ] ]
-    ui_strut 0.5
-    ui_center [ ui_text "You are about to restore the Blue Nebula default keyboard binds." ]
-    ui_strut 0.25
-    ui_font "little" [
-        ui_center [ ui_text "Keys that have not been bound to a function by default will remain unchanged." ]
-        ui_center [ ui_text "If you wish to restore only a single bind, you must close Blue Nebula, open the user" ]
-    ui_center [ ui_text "config file in the home folder (config.cfg), delete the appropriate entry, then save." ]
-    ]
-    ui_strut 1
-    ui_checkbox "Mumble Positional Audio" mumble
-    ui_checkbox "Play Map-Specific Sounds" soundenvvol [1.0 0]
-    ui_strut 1
-    ui_button "^fyOpen Sound Debugger" [show_ui cursounds]
-]
 
 keyboard_options = [
     ui_center [


### PR DESCRIPTION
Due to my previous PR #14 there was a bug introduced which would create a duplicate of the "ui" resetcontrols which would make the "reset controls to default" button unable to function correctly