### PR TITLE
Add option to hide incompatible servers from serverbrowser

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -631,6 +631,8 @@ options_serverbrowser = [
     ui_strut 0.4
 
     ui_checkbox (format "^fc%1" "Show Server Version") serverbrowser_show_server_platform_and_branch // show_server_platform_and_branch checkbox
+    ui_strut 0.5
+    ui_checkbox (format "^fo%1" "Hide Incompatible Servers") hideincompatibleservers
 ]
 
 // RADAR OPTIONS

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -18,6 +18,7 @@ namespace client
     VAR(IDF_PERSIST, showteamchange, 0, 1, 2); // 0 = never show, 1 = show only when switching between, 2 = show when entering match too
     VAR(IDF_PERSIST, showservervariables, 0, 0, 1); // determines if variables set by the server are printed to the console
     VAR(IDF_PERSIST, showmapvotes, 0, 1, 3); // shows map votes, 1 = only mid-game (not intermision), 2 = at all times, 3 = verbose
+    VAR(IDF_PERSIST, hideincompatibleservers, 0, 0, 1);
 
     VAR(IDF_PERSIST, checkpointannounce, 0, 5, 7); // 0 = never, &1 = active players, &2 = all players, &4 = all players in gauntlet
     VAR(IDF_PERSIST, checkpointannouncefilter, 0, CP_ALL, CP_ALL); // which checkpoint types to announce for
@@ -3389,10 +3390,39 @@ namespace client
 
     void getservers(int server, int prop, int idx)
     {
-        if(server < 0) intret(servers.length());
+        if(server < 0) 
+        {
+            if (hideincompatibleservers)
+            {
+                vector<serverinfo *> servers_new;
+                for (int i = 0; i < servers.length(); i++)
+                {
+                    serverinfo* si = servers[i];
+                    // check that the server is compatible
+                    if (si->attr.inrange(0))
+                    {
+                        if (si->attr[0] == server::getver(1))
+                        {
+                            servers_new.add(servers[i]);
+                        }
+                    }
+                    else
+                    {
+                        if (client::serverstat(si) != 2)
+                        {
+                            servers_new.add(servers[i]);
+                        }
+                    }
+                }
+                servers = servers_new;
+            }
+
+            intret(servers.length());
+        }
         else if(servers.inrange(server))
         {
             serverinfo *si = servers[server];
+
             if(prop < 0) intret(4);
             else switch(prop)
             {

--- a/src/shared/igame.h
+++ b/src/shared/igame.h
@@ -47,6 +47,7 @@ namespace client
     extern int servercompare(serverinfo *a, serverinfo *b);
     extern const char *getname();
     extern bool sendcmd(int nargs, const char *cmd, const char *arg);
+    extern int serverstat(serverinfo* a);
 }
 
 namespace hud


### PR DESCRIPTION
This PR adds a new checkbox to the Serverbrowser options called "Hide Incompatible Servers" which will ... well, hide the incompatible servers in the serverbrowser. I know, it ain't much but I think it's nice to have