### PR TITLE
Customizable compass menu

### DIFF
--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -100,4 +100,4 @@ newcompass bot "textures/hud/voices" [
 bind V [showcompass voice]
 bind X [showcompass team]
 bind B [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
-bind LALT [ showcompass Custom ]
+bind C [ showcompass Custom ]

--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -1,3 +1,12 @@
+newcompass Custom "textures/menu" [
+    if $customcompassentryname1 [ compass $customcompassentryname1 [ ui_execute [ @customcompassentryaction1 ] ] ]
+    if $customcompassentryname2 [ compass $customcompassentryname2 [ ui_execute [ @customcompassentryaction2 ] ] ]
+    if $customcompassentryname3 [ compass $customcompassentryname3 [ ui_execute [ @customcompassentryaction3 ] ] ]
+    if $customcompassentryname4 [ compass $customcompassentryname4 [ ui_execute [ @customcompassentryaction4 ] ] ]
+    if $customcompassentryname5 [ compass $customcompassentryname5 [ ui_execute [ @customcompassentryaction5 ] ] ]
+    if $customcompassentryname6 [ compass $customcompassentryname6 [ ui_execute [ @customcompassentryaction6 ] ] ]
+]
+
 newcompass main "textures/menu" [
     compass "menus" [showcompass menus]
     compass "voice" [showcompass voice]
@@ -91,3 +100,4 @@ newcompass bot "textures/hud/voices" [
 bind V [showcompass voice]
 bind X [showcompass team]
 bind B [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
+bind LALT [ showcompass custom ]

--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -100,4 +100,4 @@ newcompass bot "textures/hud/voices" [
 bind V [showcompass voice]
 bind X [showcompass team]
 bind B [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
-bind LALT [ showcompass custom ]
+bind LALT [ showcompass Custom ]

--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -159,6 +159,13 @@ new_ui options_menu_ui [
     ui_stay_open [
         options_console
     ]
+
+    // Custom compass
+    ui_tab "Custom Compass"
+    ui_strut 0.5
+    ui_stay_open [
+        options_custom_compass
+    ]   
 ]
 
 // CONSOLE OPTIONS
@@ -277,6 +284,43 @@ options_console = [
         ]
     ]
     ui_font "little" [ ui_text "^faDefault: 32" ]
+]
+
+// CUSTOM COMPASS OPTIONS
+options_custom_compass = [
+    ui_list [
+        ui_list [
+            ui_strut 0 20
+            ui_text "   Name"
+            ui_list [ ui_text "1  "; ui_textfield customcompassentryname1 25 ]
+            ui_strut 0.1
+            ui_list [ ui_text "2  "; ui_textfield customcompassentryname2 25 ]
+            ui_strut 0.1
+            ui_list [ ui_text "3  "; ui_textfield customcompassentryname3 25 ]
+            ui_strut 0.1
+            ui_list [ ui_text "4  "; ui_textfield customcompassentryname4 25 ]
+            ui_strut 0.1
+            ui_list [ ui_text "5  "; ui_textfield customcompassentryname5 25 ]
+            ui_strut 0.1
+            ui_list [ ui_text "6  "; ui_textfield customcompassentryname6 25 ]
+        ]
+
+        ui_list [
+            ui_strut 0 75
+            ui_text "Action"
+            ui_textfield customcompassentryaction1 100
+            ui_strut 0.1
+            ui_textfield customcompassentryaction2 100
+            ui_strut 0.1
+            ui_textfield customcompassentryaction3 100
+            ui_strut 0.1
+            ui_textfield customcompassentryaction4 100
+            ui_strut 0.1
+            ui_textfield customcompassentryaction5 100
+            ui_strut 0.1
+            ui_textfield customcompassentryaction6 100
+        ]
+    ]
 ]
 
 // GENERAL OPTIONS

--- a/src/engine/menus.cpp
+++ b/src/engine/menus.cpp
@@ -11,6 +11,19 @@ struct menu;
 static guient *cgui = NULL;
 static menu *cmenu = NULL;
 
+SVAR(IDF_PERSIST, customcompassentryname1, "");
+SVAR(IDF_PERSIST, customcompassentryname2, "");
+SVAR(IDF_PERSIST, customcompassentryname3, "");
+SVAR(IDF_PERSIST, customcompassentryname4, "");
+SVAR(IDF_PERSIST, customcompassentryname5, "");
+SVAR(IDF_PERSIST, customcompassentryname6, "");
+SVAR(IDF_PERSIST, customcompassentryaction1, "");
+SVAR(IDF_PERSIST, customcompassentryaction2, "");
+SVAR(IDF_PERSIST, customcompassentryaction3, "");
+SVAR(IDF_PERSIST, customcompassentryaction4, "");
+SVAR(IDF_PERSIST, customcompassentryaction5, "");
+SVAR(IDF_PERSIST, customcompassentryaction6, "");
+
 struct menu : guicb
 {
     char *name, *header;
@@ -663,6 +676,11 @@ void ui_list(uint *contents)
     cgui->poplist();
 }
 
+void ui_execute(char* contents)
+{
+    execute(contents);
+}
+
 void newgui(char *name, char *contents, char *initscript)
 {
     menu *m = menus.access(name);
@@ -737,6 +755,7 @@ COMMAND(0, ui_tooltip, "si");
 COMMAND(0, ui_textfield, "sisbisisi");
 COMMAND(0, ui_keyfield, "sisbissi");
 COMMAND(0, ui_editor, "siiibisss");
+COMMAND(0, ui_execute , "s");
 
 ICOMMAND(0, guicount, "", (), intret(menustack.length()));
 ICOMMAND(0, ui_font_width, "s", (char * font), intret(ui_font_width(font)));


### PR DESCRIPTION
Adds new tab to the User Interface Options:
![NewTab](https://user-images.githubusercontent.com/37220464/84682333-c9ae6b00-af35-11ea-85d8-add212559d4c.png)
You can modify up to 6 shortcuts by setting a name and entering any cubescript command in the action field like this:
![ShowcaseCommand](https://user-images.githubusercontent.com/37220464/84682408-e2b71c00-af35-11ea-98dd-8fc4a27b7b94.png)
In-Game you can then press the C key (rebindable) and it'll pop up a compass menu:
![OpenMenu](https://user-images.githubusercontent.com/37220464/84682476-f8c4dc80-af35-11ea-85fd-ab38bd1da701.png)
they work exactly like the voiceline compass menus, so when you press a shortcut (in this case: "Hello World!") and it'll execute the command you entered before
![Demonstration](https://user-images.githubusercontent.com/37220464/84682576-23169a00-af36-11ea-949d-1d352c6c3257.png)

Closes #45.
