### PR TITLE
Add ability to use Alt + Backspace to delete entire words in the console

### DIFF
--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -512,16 +512,20 @@ bool consolekey(int code, bool isdown)
                 if (holding_alt)
                 {
                     char* last_word = strrchr(commandbuf, ' ');
-                    if (last_word)
+                    if (last_word != NULL)
                     {
-                        commandbuf[(commandbuf_len - strlen(last_word))] = 0;
+                        // add 1 to the len to only remove the word without the space, as this will be removed later
+                        size_t new_len = (last_word - commandbuf) + 1;
+                        commandbuf[new_len] = '\0';
+                        commandbuf_len = new_len;
                     }
                     else
                     {
-                        commandbuf[0] = 0;
+                        commandbuf[0] = '\0';
+                        commandbuf_len = 0;
                     }
                 }
-                
+
 
                 int len = (int)commandbuf_len, i = commandpos>=0 ? commandpos : len;
                 if(i<1) break;

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -12,6 +12,7 @@ bigstring commandbuf;
 char *commandaction = NULL, *commandicon = NULL;
 enum { CF_COMPLETE = 1<<0, CF_EXECUTE = 1<<1, CF_MESSAGE = 1<<2 };
 int commandflags = 0, commandpos = -1, commandcolour = 0;
+bool holding_alt = false;
 
 void complete(char* s, size_t s_size, const char* cmdprefix);
 
@@ -506,7 +507,21 @@ bool consolekey(int code, bool isdown)
 
             case SDLK_BACKSPACE:
             {
-                int len = (int)strlen(commandbuf), i = commandpos>=0 ? commandpos : len;
+                size_t commandbuf_len = strlen(commandbuf);
+                if (holding_alt)
+                {
+                    char* last_word = strrchr(commandbuf, ' ');
+                    if (last_word)
+                    {
+                        commandbuf[(commandbuf_len - strlen(last_word))] = 0;
+                    }
+                    else
+                    {
+                        commandbuf[0] = 0;
+                    }
+                }
+
+                int len = (int)commandbuf_len, i = commandpos>=0 ? commandpos : len;
                 if(i<1) break;
                 memmove(&commandbuf[i-1], &commandbuf[i], len - i + 1);
                 resetcomplete();
@@ -607,6 +622,7 @@ void processtextinput(const char *str, int len)
         return; \
     } \
 }
+
 void processkey(int code, bool isdown)
 {
     switch(code)
@@ -631,6 +647,9 @@ void processkey(int code, bool isdown)
             break;
         case SDLK_NUMLOCKCLEAR:
             if(!isdown) numlockon = numlocked();
+            break;
+        case SDLK_LALT:
+            holding_alt = isdown;
             break;
         default: break;
     }

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -521,6 +521,7 @@ bool consolekey(int code, bool isdown)
                         commandbuf[0] = 0;
                     }
                 }
+                
 
                 int len = (int)commandbuf_len, i = commandpos>=0 ? commandpos : len;
                 if(i<1) break;

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -508,14 +508,15 @@ bool consolekey(int code, bool isdown)
             case SDLK_BACKSPACE:
             {
                 size_t commandbuf_len = strlen(commandbuf);
-                
+
                 // when holding alt, remove the entire last word
                 if (holding_alt)
                 {
                     char* last_word = strrchr(commandbuf, ' ');
                     if (last_word != NULL)
                     {
-                        // add 1 to the len to only remove the word without the space, as this will be removed later
+                        // the code following this block will remove another character anyway
+                        // therefore, we add 1 and let that code remove the space then
                         size_t new_len = (last_word - commandbuf) + 1;
                         commandbuf[new_len] = '\0';
                         commandbuf_len = new_len;

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -512,6 +512,7 @@ bool consolekey(int code, bool isdown)
                 if (SDL_GetModState() & KMOD_ALT)
                 {
                     char* last_word = strrchr(commandbuf, ' ');
+
                     if (last_word != NULL)
                     {
                         // the code following this block will remove another character anyway
@@ -526,7 +527,6 @@ bool consolekey(int code, bool isdown)
                         commandbuf_len = 0;
                     }
                 }
-
 
                 int len = (int)commandbuf_len, i = commandpos>=0 ? commandpos : len;
                 if(i<1) break;

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -12,7 +12,6 @@ bigstring commandbuf;
 char *commandaction = NULL, *commandicon = NULL;
 enum { CF_COMPLETE = 1<<0, CF_EXECUTE = 1<<1, CF_MESSAGE = 1<<2 };
 int commandflags = 0, commandpos = -1, commandcolour = 0;
-bool holding_alt = false;
 
 void complete(char* s, size_t s_size, const char* cmdprefix);
 
@@ -510,7 +509,7 @@ bool consolekey(int code, bool isdown)
                 size_t commandbuf_len = strlen(commandbuf);
 
                 // when holding alt, remove the entire last word
-                if (holding_alt)
+                if (SDL_GetModState() & KMOD_ALT)
                 {
                     char* last_word = strrchr(commandbuf, ' ');
                     if (last_word != NULL)
@@ -655,9 +654,6 @@ void processkey(int code, bool isdown)
             break;
         case SDLK_NUMLOCKCLEAR:
             if(!isdown) numlockon = numlocked();
-            break;
-        case SDLK_LALT:
-            holding_alt = isdown;
             break;
         default: break;
     }

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -508,6 +508,7 @@ bool consolekey(int code, bool isdown)
             case SDLK_BACKSPACE:
             {
                 size_t commandbuf_len = strlen(commandbuf);
+                // when holding alt, remove the entire last word
                 if (holding_alt)
                 {
                     char* last_word = strrchr(commandbuf, ' ');

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -508,6 +508,7 @@ bool consolekey(int code, bool isdown)
             case SDLK_BACKSPACE:
             {
                 size_t commandbuf_len = strlen(commandbuf);
+                
                 // when holding alt, remove the entire last word
                 if (holding_alt)
                 {


### PR DESCRIPTION
Hold LALT and press backspace to delete an entire word in the console

Closes #54.