### PR TITLE
Add Show Server Sort Options checkbox to Serverbrowser Options

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -632,6 +632,8 @@ options_serverbrowser = [
 
     ui_checkbox (format "^fc%1" "Show Server Version") serverbrowser_show_server_platform_and_branch // show_server_platform_and_branch checkbox
     ui_strut 0.5
+    ui_checkbox (format "^fy%1" "Show Server Sort Options") showserversortoptions
+    ui_strut 0.5
     ui_checkbox (format "^fo%1" "Hide Incompatible Servers") hideincompatibleservers
 ]
 


### PR DESCRIPTION
Adds this checkbox:
![Checkbox](https://user-images.githubusercontent.com/37220464/84678155-f8294780-af2f-11ea-8219-ca9c7c2698c8.png)
to toggle this:
![Serverbrowser](https://user-images.githubusercontent.com/37220464/84678236-0f683500-af30-11ea-8e2b-63d72b089e97.png)
Why? because the only way to toggle it before was to set `showserversortoptions` to `1`
Why was this the only way? because before we didn't have the Serverbrowser options and to keep everything clean we just moved it so only "advanced" people could find it because we figured that nobody really used those options anyways
