### PR TITLE
Fix small bug in serverbrowser

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -188,7 +188,7 @@ server_menu = [
                 ui_background $ui_color_textfield_background $ui_blend_textfield_background $ui_color_textfield_border $ui_blend_textfield_border
                 ui_list [
                     ui_strut 1
-                    ui_text (format "^fc%1 ^fwPlayers on ^fc%2 ^fwof ^fc%3 ^fwServer%5" $serverinfo_players $serverinfo_servers $serverinfo_server_count (? (!= $serverinfo_server_count 1) "s"))
+                    ui_text (format "^fc%1 ^fwPlayers on ^fc%2 ^fwof ^fc%3 ^fwServer%4" $serverinfo_players $serverinfo_servers $serverinfo_server_count (? (!= $serverinfo_server_count 1) "s"))
                     ui_strut 1
                 ]
             ]


### PR DESCRIPTION
I noticed a small bug in the serverbrowser where previously it wouldn't append a "s" to "Server" if needed.
Previously:
![Bugged](https://user-images.githubusercontent.com/37220464/84893906-4c533980-b0a0-11ea-9c62-fbaf59df9447.png)
Now:
![Fixed](https://user-images.githubusercontent.com/37220464/84893918-5117ed80-b0a0-11ea-9166-4288df2c72ef.png)
