### PR TITLE
Fix edit mode entity update bug

### DIFF
--- a/src/engine/world.cpp
+++ b/src/engine/world.cpp
@@ -1183,5 +1183,6 @@ void mpeditent(int i, const vec &o, int type, attrvector &attr, bool local)
         e.attrs.add(0, max(entities::numattrs(e.type), min(attr.length(), MAXENTATTRS)) - e.attrs.length());
         loopk(min(attr.length(), e.attrs.length())) e.attrs[k] = attr[k];
         addentity(i);
+        entities::editent(i, false);
     }
 }

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -1254,12 +1254,18 @@ namespace entities
         if(!m_edit(game::gamemode) && suicide) game::suicide(d, HIT_SPAWN);
     }
 
-    void editent(int i)
+    void editent(int i, bool local)
     {
         extentity &e = *ents[i];
-        fixentity(i, true);
-        if(m_edit(game::gamemode) && game::player1.state == CS_EDITING)
-            client::addmsg(N_EDITENT, "ri5iv", i, (int)(e.o.x*DMF), (int)(e.o.y*DMF), (int)(e.o.z*DMF), e.type, e.attrs.length(), e.attrs.length(), e.attrs.getbuf()); // FIXME
+        if (local)
+        {
+            fixentity(i, true);
+            if(m_edit(game::gamemode) && game::player1.state == CS_EDITING)
+            {
+                client::addmsg(N_EDITENT, "ri5iv", i, (int)(e.o.x*DMF), (int)(e.o.y*DMF), (int)(e.o.z*DMF), e.type, e.attrs.length(), e.attrs.length(), e.attrs.getbuf()); // FIXME
+            }
+        }
+
         if(e.type < MAXENTTYPES)
         {
             lastenttype[e.type] = max(lastenttype[e.type], i+1);

--- a/src/shared/igame.h
+++ b/src/shared/igame.h
@@ -4,7 +4,7 @@ namespace entities
 {
     extern int numattrs(int type);
     extern int triggertime(extentity &e);
-    extern void editent(int i);
+    extern void editent(int i, bool local = true);
     extern void readent(stream *g, int mtype, int mver, char *gid, int gver, int id);
     extern void writeent(stream *g, int id);
     extern void remapents(vector<int> &idxs);


### PR DESCRIPTION
as described in issue #64 triggers wouldn't work on entities that you have never touched (literally, once you clicked on them, they were added to a list and they'd start working) ,I fixed this by calling the function that gets called when you edit an entity (`entities::editent(...)`) when the server sends an `N_EDITENT` event