### PR TITLE
Fix serverbrowser first entry is smaller than the others bug

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -326,7 +326,7 @@ server_menu = [
                         title = (format "^fo%1" $serverinfo_title)
                     ]
 
-                    ui_font "emhpasis" [ ui_button $title ]
+                    ui_font "emphasis" [ ui_button $title ]
 
                     // show ip and port
                     ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ] 
@@ -355,7 +355,7 @@ server_menu = [
                                 ui_button (format " ^fd[^fc%1^fd:^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
                             ]
                             gname = (gamename $serverinfo_mode $serverinfo_mutators 0 32)
-                            ui_font "normal" [ ui_center [ ui_list [
+                            ui_font "little" [ ui_center [ ui_list [
                                 // show map name
                                 ui_button (format " ^fy%1 ^faon ^fo%2" $gname $serverinfo_map_name)
 


### PR DESCRIPTION
There was a bug occuring in the serverbrowser where the first item in the list was smaller than the others:
![Glitch](https://user-images.githubusercontent.com/37220464/85023932-a2de7780-b175-11ea-8e03-4f269e338934.png)
This is how it looks now:
![Fixed](https://user-images.githubusercontent.com/37220464/85024010-c6092700-b175-11ea-8102-2bc4f60dea0c.png)
I had a typo in the font name of the title, I wrote `emhpasis` instead of `emphasis` and also as it turns out, there isn't enough space for using `normal` as font for the line underneigh the title so I changed it back to `little`