### PR TITLE
Fix zoom crash/freeze.

### DIFF
--- a/src/game/weapons.h
+++ b/src/game/weapons.h
@@ -248,8 +248,8 @@ WPVARM(IDF_GAMEMOD,  cooktime, 0, VAR_MAX,
     0,          0,          0,          0,          0,          0,          0,          0,          0,          3000,       0,          0,          0,
     0,          0,          0,          0,          0,          0,          2000,       0,          650,        3000,       0,          0,          0
 );
-WPVAR(IDF_GAMEMOD,  cookzoom, 0, VAR_MAX,
-    0,          0,          0,          0,          0,          0,          0,          0,          650,        0,          0,          0,          0
+WPVAR(IDF_GAMEMOD,  cookzoom, 1, VAR_MAX,
+    1,          1,          1,          1,          1,          1,          1,          1,          650,        1,          1,          1,          1
 );
 WPFVAR(IDF_GAMEMOD,  cookzoommin, 1, 150,
     10,         10,         10,         10,         10,         10,         10,         10,         10,         10,         10,         10,         10


### PR DESCRIPTION
To reproduce the freeze in master, zoom with the rifle and press `1` to switch to the pistol. `firstpersonbob` must be enabled.
This was caused by dividing by the `cookzoom` variable of the pistol, which is zero. The code assumes it is non-zero.
This can also occur when a weapon that should zoom has a `cookzoom` of zero: stopping the zoom will freeze/crash.

Alternative solution: add checks everywhere `cookzoom` is used to ensure there is no div by zero.

Examples of place where this division happens (search for uses of `cookzoom` in `game.cpp`):
https://github.com/blue-nebula/base/blob/4a47f01f239d9b580e2cf2e8da853ba97ff219ba/src/game/game.cpp#L1009-L1014
https://github.com/blue-nebula/base/blob/4a47f01f239d9b580e2cf2e8da853ba97ff219ba/src/game/game.cpp#L2304-L2310