### PR TITLE
Fix cookzoom crash.

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1010,7 +1010,7 @@ namespace game
                 int frame = lastmillis-lastzoom;
 
                 float pc = 1.f;
-                if (W(focus->weapselect, cookzoom) > 0 && frame <= W(d->weapselect, cookzoom)) {
+                if (W(d->weapselect, cookzoom) > 0 && frame <= W(d->weapselect, cookzoom)) {
                     pc = frame / float(W(d->weapselect, cookzoom));
                 }
 
@@ -2321,7 +2321,7 @@ namespace game
                 int frame = lastmillis-lastzoom;
 
                 float pc = 1.f;
-                if (W(focus->weapselect, cookzoom) > 0 && frame <= W(e->weapselect, cookzoom)) {
+                if (W(e->weapselect, cookzoom) > 0 && frame <= W(e->weapselect, cookzoom)) {
                     pc = frame / float(W(e->weapselect, cookzoom));
                 }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -528,9 +528,7 @@ namespace game
 
     bool inzoom()
     {
-        if(lastzoom && (zooming || lastmillis-lastzoom <= W(focus->weapselect, cookzoom)))
-            return true;
-        return false;
+        return lastzoom && (zooming || lastmillis - lastzoom <= W(focus->weapselect, cookzoom));
     }
     ICOMMAND(0, iszooming, "", (), intret(inzoom() ? 1 : 0));
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -533,13 +533,13 @@ namespace game
     ICOMMAND(0, iszooming, "", (), intret(inzoom() ? 1 : 0));
 
     // Get the progress ratio of the zoom in the interval [0, 1], where 0 is no zoom and 1 is full zoom.
-    float zoom_ratio(gameent *d)
+    float zoom_ratio()
     {
         // Time since the last zoom state change.
         int frame = lastmillis - lastzoom;
 
         // Time for the weapon to change zoom state.
-        int cookzoom = W(d->weapselect, cookzoom);
+        int cookzoom = W(focus->weapselect, cookzoom);
 
         // Calculate how far along the zoom state change is.
         // A cookzoom of 0 means there is instant state change, which is always a completed ratio of 1.
@@ -1039,7 +1039,7 @@ namespace game
             // Scale opacity by the zoom-out ratio so that the player becomes transparent while zoomed and opaque while not zoomed.
             if(d == focus && inzoom())
             {
-                total *= 1.f - zoom_ratio(d);
+                total *= 1.f - zoom_ratio();
             }
         }
         else if(d->state == CS_EDITING) total *= playereditblend;
@@ -2176,7 +2176,7 @@ namespace game
             float zoom = cookzoommax - ((cookzoommax - cookzoommin) / float(zoomlevels) * zoomlevel);
             float diff = float(fov()-zoom);
 
-            curfov = fov() - (zoom_ratio(focus) * diff);
+            curfov = fov() - (zoom_ratio() * diff);
         }
         else curfov = float(fov());
     }
@@ -2335,7 +2335,7 @@ namespace game
             float scale = 1;
             if(gameent::is(d) && d == focus && inzoom())
             {
-                scale *= 1.f - zoom_ratio((gameent *)d);
+                scale *= 1.f - zoom_ratio();
             }
             if(firstpersonbobtopspeed) scale *= clamp(d->vel.magnitude()/firstpersonbobtopspeed, firstpersonbobmin, 1.f);
             if(scale > 0)
@@ -2785,7 +2785,7 @@ namespace game
             float scale = 1;
             if(d == focus && inzoom())
             {
-                scale *= 1.f - zoom_ratio(d);
+                scale *= 1.f - zoom_ratio();
             }
             if(firstpersonbobtopspeed) scale *= clamp(d->vel.magnitude()/firstpersonbobtopspeed, firstpersonbobmin, 1.f);
             if(scale > 0)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1004,10 +1004,16 @@ namespace game
             if(d == focus && third) total *= camera1->o.dist(d->o)/(d != &player1 ? followdist : thirdpersondist);
             int prot = m_protect(gamemode, mutators), millis = d->protect(lastmillis, prot); // protect returns time left
             if(millis > 0) total *= 1.f-(float(millis)/float(prot));
+
             if(d == focus && inzoom())
             {
                 int frame = lastmillis-lastzoom;
-                float pc = frame <= W(d->weapselect, cookzoom) ? (frame)/float(W(d->weapselect, cookzoom)) : 1.f;
+
+                float pc = 1.f;
+                if (W(focus->weapselect, cookzoom) > 0 && frame <= W(d->weapselect, cookzoom)) {
+                    pc = frame / float(W(d->weapselect, cookzoom));
+                }
+
                 total *= zooming ? 1.f-pc : pc;
             }
         }
@@ -2138,10 +2144,19 @@ namespace game
         if(inzoom())
         {
             checkzoom();
+
             int frame = lastmillis-lastzoom;
-            float zoom = W(game::focus->weapselect, cookzoommax)-((W(game::focus->weapselect, cookzoommax)-W(game::focus->weapselect, cookzoommin))/float(zoomlevels)*zoomlevel),
-                  diff = float(fov()-zoom), amt = frame < W(focus->weapselect, cookzoom) ? clamp(frame/float(W(focus->weapselect, cookzoom)), 0.f, 1.f) : 1.f;
-            if(!zooming) amt = 1.f-amt;
+            float zoom = W(game::focus->weapselect, cookzoommax)-((W(game::focus->weapselect, cookzoommax)-W(game::focus->weapselect, cookzoommin))/float(zoomlevels)*zoomlevel);
+            float diff = float(fov()-zoom);
+
+            float amt = 1.f;
+            if (W(focus->weapselect, cookzoom) > 0 && frame < W(focus->weapselect, cookzoom)) {
+                amt = clamp(frame / float(W(focus->weapselect, cookzoom)), 0.f, 1.f);
+            }
+
+            if(!zooming)
+                amt = 1.f-amt;
+
             curfov = fov()-(amt*diff);
         }
         else curfov = float(fov());
@@ -2302,8 +2317,14 @@ namespace game
             if(gameent::is(d) && d == focus && inzoom())
             {
                 gameent *e = (gameent *)d;
+
                 int frame = lastmillis-lastzoom;
-                float pc = frame <= W(e->weapselect, cookzoom) ? (frame)/float(W(e->weapselect, cookzoom)) : 1.f;
+
+                float pc = 1.f;
+                if (W(focus->weapselect, cookzoom) > 0 && frame <= W(e->weapselect, cookzoom)) {
+                    pc = frame / float(W(e->weapselect, cookzoom));
+                }
+
                 scale *= zooming ? 1.f-pc : pc;
             }
             if(firstpersonbobtopspeed) scale *= clamp(d->vel.magnitude()/firstpersonbobtopspeed, firstpersonbobmin, 1.f);
@@ -2755,7 +2776,12 @@ namespace game
             if(d == focus && inzoom())
             {
                 int frame = lastmillis-lastzoom;
-                float pc = frame <= W(d->weapselect, cookzoom) ? (frame)/float(W(d->weapselect, cookzoom)) : 1.f;
+
+                float pc = 1.f;
+                if (frame <= W(d->weapselect, cookzoom) && W(d->weapselect, cookzoom) > 0) {
+                    pc = frame / float(W(d->weapselect, cookzoom));
+                }
+
                 scale *= zooming ? 1.f-pc : pc;
             }
             if(firstpersonbobtopspeed) scale *= clamp(d->vel.magnitude()/firstpersonbobtopspeed, firstpersonbobmin, 1.f);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1739,7 +1739,7 @@ namespace game
     extern int deadzone();
     extern void checkzoom();
     extern bool inzoom();
-    extern float zoom_ratio(gameent *d);
+    extern float zoom_ratio();
     extern void zoomview(bool down);
     extern bool tvmode(bool check = true, bool force = true);
     extern void resetcamera(bool cam = true, bool input = true);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1739,7 +1739,7 @@ namespace game
     extern int deadzone();
     extern void checkzoom();
     extern bool inzoom();
-    extern float zoomratio(gameent *d);
+    extern float zoom_ratio(gameent *d);
     extern void zoomview(bool down);
     extern bool tvmode(bool check = true, bool force = true);
     extern void resetcamera(bool cam = true, bool input = true);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1739,6 +1739,7 @@ namespace game
     extern int deadzone();
     extern void checkzoom();
     extern bool inzoom();
+    extern float zoomratio(gameent *d);
     extern void zoomview(bool down);
     extern bool tvmode(bool check = true, bool force = true);
     extern void resetcamera(bool cam = true, bool input = true);

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1323,7 +1323,10 @@ namespace hud
             if(index == POINTER_ZOOM && game::inzoom())
             {
                 int frame = lastmillis-game::lastzoom, off = int(zoomcrosshairsize*hudsize)-cs;
-                float amt = frame <= W(game::focus->weapselect, cookzoom) ? clamp(float(frame)/float(W(game::focus->weapselect, cookzoom)), 0.f, 1.f) : 1.f;
+                float amt = 1.f;
+                if (W(game::focus->weapselect, cookzoom) > 0 && frame < W(game::focus->weapselect, cookzoom)) {
+                    amt = clamp(frame / float(W(game::focus->weapselect, cookzoom)), 0.f, 1.f);
+                }
                 if(!game::zooming) amt = 1.f-amt;
                 cs += int(off*amt);
                 fade += (zoomcrosshairblend-fade)*amt;
@@ -3144,11 +3147,11 @@ namespace hud
                 memcpy(prevstats, curstats, sizeof(prevstats));
                 laststats = totalmillis-(totalmillis%statrate);
             }
-            
+
             int nextstats[NUMSTATS] = {
                 vtris*100/max(wtris, 1), vverts*100/max(wverts, 1), xtraverts/1024, xtravertsva/1024, glde, gbatches, getnumqueries(), rplanes, curfps, bestfpsdiff, worstfpsdiff
             };
-            
+
             loopi(NUMSTATS) if(prevstats[i] == curstats[i]) curstats[i] = nextstats[i];
 
             pushfont("consub");
@@ -3201,10 +3204,10 @@ namespace hud
 
         if(!minimal(showinventory, true))
             return left;
-        
+
         float fade = blend*inventoryblend;
         bool interm = !gs_playing(game::gamestate) && game::tvmode() && game::focus == &game::player1;
-        
+
         loopi(2) switch(i)
         {
             case 0:
@@ -3295,7 +3298,10 @@ namespace hud
     {
         Texture *t = textureload(zoomtex, 3);
         int frame = lastmillis-game::lastzoom;
-        float pc = frame <= W(game::focus->weapselect, cookzoom) ? float(frame)/float(W(game::focus->weapselect, cookzoom)) : 1.f;
+        float pc = 1.f;
+        if (W(game::focus->weapselect, cookzoom) > 0 && frame <= W(game::focus->weapselect, cookzoom)) {
+            pc = frame / float(W(game::focus->weapselect, cookzoom));
+        }
         if(!game::zooming) pc = 1.f-pc;
         int x = 0, y = 0, c = 0;
         if(w > h)

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1324,7 +1324,7 @@ namespace hud
             {
                 int off = int(zoomcrosshairsize*hudsize)-cs;
                 // Focused zoom ratio
-                float zr = game::zoom_ratio(game::focus);
+                float zr = game::zoom_ratio();
                 cs += int(off * zr);
                 fade += (zoomcrosshairblend - fade) * zr;
             }
@@ -3294,7 +3294,7 @@ namespace hud
     void drawzoom(int w, int h)
     {
         Texture *t = textureload(zoomtex, 3);
-        float pc = game::zoom_ratio(game::focus);
+        float pc = game::zoom_ratio();
         int x = 0, y = 0, c = 0;
         if(w > h)
         {

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1324,7 +1324,7 @@ namespace hud
             {
                 int off = int(zoomcrosshairsize*hudsize)-cs;
                 // Focused zoom ratio
-                float zr = game::zoomratio(game::focus);
+                float zr = game::zoom_ratio(game::focus);
                 cs += int(off * zr);
                 fade += (zoomcrosshairblend - fade) * zr;
             }
@@ -3294,7 +3294,7 @@ namespace hud
     void drawzoom(int w, int h)
     {
         Texture *t = textureload(zoomtex, 3);
-        float pc = game::zoomratio(game::focus);
+        float pc = game::zoom_ratio(game::focus);
         int x = 0, y = 0, c = 0;
         if(w > h)
         {

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1322,14 +1322,11 @@ namespace hud
             if(crosshairweapons&2) c = vec::hexcolor(W(game::focus->weapselect, colour));
             if(index == POINTER_ZOOM && game::inzoom())
             {
-                int frame = lastmillis-game::lastzoom, off = int(zoomcrosshairsize*hudsize)-cs;
-                float amt = 1.f;
-                if (W(game::focus->weapselect, cookzoom) > 0 && frame < W(game::focus->weapselect, cookzoom)) {
-                    amt = clamp(frame / float(W(game::focus->weapselect, cookzoom)), 0.f, 1.f);
-                }
-                if(!game::zooming) amt = 1.f-amt;
-                cs += int(off*amt);
-                fade += (zoomcrosshairblend-fade)*amt;
+                int off = int(zoomcrosshairsize*hudsize)-cs;
+                // Focused zoom ratio
+                float zr = game::zoomratio(game::focus);
+                cs += int(off * zr);
+                fade += (zoomcrosshairblend - fade) * zr;
             }
             if(crosshairtone) skewcolour(c.r, c.g, c.b, crosshairtone);
             int heal = m_health(game::gamemode, game::mutators, game::focus->actortype);
@@ -3297,12 +3294,7 @@ namespace hud
     void drawzoom(int w, int h)
     {
         Texture *t = textureload(zoomtex, 3);
-        int frame = lastmillis-game::lastzoom;
-        float pc = 1.f;
-        if (W(game::focus->weapselect, cookzoom) > 0 && frame <= W(game::focus->weapselect, cookzoom)) {
-            pc = frame / float(W(game::focus->weapselect, cookzoom));
-        }
-        if(!game::zooming) pc = 1.f-pc;
+        float pc = game::zoomratio(game::focus);
         int x = 0, y = 0, c = 0;
         if(w > h)
         {


### PR DESCRIPTION
Replacement of #82 

Avoids dividing by zero in places where `cookzoom` is used which ultimately results an infinite loop.

Fixes the freeze reproduceable in master by zooming with rifle and switching to another weapon with a number key (must have `firstpersonbob 0` and no compiler optimizations and ffast-math).