### PR TITLE
Fix serverbrowser search bug

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -9,6 +9,7 @@ serverinfo_players = 0
 serverinfo_servers = 0
 serverinfo_server_count = 0
 serverinfo_ui_time = 0
+search_str = ""
 
 spacing_between_serverinfos = 0.3
 
@@ -67,7 +68,6 @@ initialise_server_menu = [
     shown_server_ui = 0
     update_server_ui = 0
     search_filter = 1
-    search_str = ""
 ]
 server_menu_iterator = [
     if (! $shown_server_ui) [
@@ -486,6 +486,7 @@ new_ui Servers [
 ] [
     if (= $guipasses 0) [
         initialise_server_menu
+        
     ]
 ]
 


### PR DESCRIPTION
Previously when you searched smth in the serverbrowser, then closed the menu and opened it again, the search term would still be written inside the searchfield but the serverbrowser itself wouldn't be filtered. I fixed this by moving `search_str = ""` outside of `initialize_server_menu` so it wouldn't get set to `""` every time you open the menu.
Bug demonstration:
Open Serverbrowser search for something (search works perfectly fine):
![Screenshot from 2020-07-01 17-41-30](https://user-images.githubusercontent.com/37220464/86264327-a553bf00-bbc2-11ea-8ff4-fb2cea9fe4ed.png)

close the serverbrowser, open it again and you see:
![Screenshot from 2020-07-01 17-41-35](https://user-images.githubusercontent.com/37220464/86264355-af75bd80-bbc2-11ea-8814-3722963720d0.png)
The search term is still inside the text field but the serverbrowser itself isn't filtered
