### PR TITLE
Move incompatible server filtering to CubeScript.

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -1,3 +1,8 @@
+hideincompatibleservers = 0
+setpersist hideincompatibleservers 1
+setcomplete hideincompatibleservers 1
+setdesc "hideincompatibleservers" "0 = do not hide protocol-incompatible servers in the browser, 1 = hide protocol-incompatible servers in the browser" "value"
+
 shown_server_ui = 0
 serverinfo_index = 0
 serverinfo_wait = 0

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -17,11 +17,11 @@ number_of_servers_shown_at_once = 5
 remove_from_sort = [
     serverinfo_type_list = ""
     serverinfo_tabsl = (? (> $serverinfo_type_list 0) $serverinfo_type_list (- 0 $serverinfo_type_list))
-    
+
     // go through all items in serversort and add all of them to new_serversort except serverinfo_type_list
     loop i (listlen $serversort) [
         serverinfo_sort_type = (at $serversort $i)
-        
+
         if $serverinfo_sort_type [
             if (!= $arg1 $serverinfo_sort_type) [
                 serverinfo_sabsl = (? (> $serverinfo_sort_type 0) $serverinfo_sort_type (- 0 $serverinfo_sort_type))
@@ -41,7 +41,7 @@ serverinfo_types = [ "" "status" "name" "port" "qport" "desc" "mode" "muts" "map
 serverinfo_modify = [
     serverinfo_type_list = $arg1
     serverinfo_tabsl = (? (> $serverinfo_type_list 0) $serverinfo_type_list (- 0 $serverinfo_type_list))
-    
+
     // loop through the serversort
     loop i (listlen $serversort) [
         serverinfo_sort_type = (at $serversort $i)
@@ -99,8 +99,6 @@ server_menu = [
         serverinfo_title          = (get_server_title $i) // this is the server name
         serverinfo_map_name       = (get_server_map_name $i)
         serverinfo_player_count   = (get_server_player_count $i)
-        serverinfo_players        = (? $i (+ $serverinfo_players $serverinfo_player_count) $serverinfo_player_count)
-        serverinfo_servers        = (? $i (? $serverinfo_player_count (+ $serverinfo_servers 1) $serverinfo_servers) (? $serverinfo_player_count 1 0))
         serverinfo_ping           = (get_server_ping $i)
         serverinfo_last           = (get_server_last $i)
         serverinfo_handle         = (get_server_handle $i)
@@ -130,7 +128,7 @@ server_menu = [
         serverinfo_game_tl        = (get_server_game_tl $i)
         serverinfo_offline_time   = (? (>= $serverinfo_last 0) (div (max (- (getmillis 1) (- $serverinfo_last (div $serverinfo_ping 2))) 0) 1000) 0)
         serverinfo_active         = (? (< $serverinfo_ping $serverwaiting) 1 0)
-        serverinfo_server_count   = (? $i (+ $serverinfo_server_count $serverinfo_active) $serverinfo_active)
+
         search_buffer             = (concat $serverinfo_title $serverinfo_name_port_id $serverinfo_map_name (gamename $serverinfo_mode $serverinfo_mutators 0) $serverinfo_handle)
         if (> $serverinfo_player_count 0 ) [
             loop j $serverinfo_player_count [
@@ -138,6 +136,35 @@ server_menu = [
                 append search_buffer (getserver $i 3 $j) // and handle
             ]
         ]
+
+        // To display a server, it must be included in the search filter (if applicable) and protocol compatible (if applicable)
+        serverinfo_filter_include = (|| (= $search_filter 0)  (> (stringcasestr $search_buffer $search_str) -1))
+        serverinfo_filter_compatible = (|| (! $hideincompatibleservers) (= $serverinfo_game_version (getversion 1)))
+        serverinfo_display = (&& $serverinfo_filter_include $serverinfo_filter_compatible)
+
+        // To count a server it must be displayable and active (returning pings)
+        serverinfo_include_in_count = (&& $serverinfo_display $serverinfo_active)
+
+        // If this is the first server, reset the counts.
+        if (= $i 0) [
+            // The number of players total.
+            serverinfo_players = 0
+            // The number of servers with players.
+            serverinfo_servers = 0
+             // The number of servers total.
+            serverinfo_server_count = 0
+        ]
+
+        // Add this server to the counts if applicable.
+        if $serverinfo_include_in_count [
+            serverinfo_players = (+ $serverinfo_players $serverinfo_player_count)
+            // Only add to the "servers with players" count if this server has players.
+            if (> $serverinfo_player_count 0) [
+                serverinfo_servers = (+ $serverinfo_servers 1)
+            ]
+            serverinfo_server_count = (+ $serverinfo_server_count 1)
+        ]
+
         if (=s $serverinfo_name_port_id $serverinfo_retry) [
             if (= $serverinfo_wait 1) [
                 if (stringlen $serverinfo_password) [
@@ -155,24 +182,27 @@ server_menu = [
                 ]
             ]
         ]
-    ] [(|| (= $search_filter 0)  (> (stringcasestr $search_buffer $search_str) -1))] [
+    ] [
+        // Only display servers that are allowed
+        $serverinfo_display
+    ] [
         if $update_server_ui [
             ui_button "^fwThere are no servers to display, maybe ^fgupdate ^fwthe list?" updatefrommaster [] "info"
         ] [
             sleep 1 [ update_server_ui = 1; updatefrommaster; serverinfo_ui_time = (getmillis) ]
         ]
-    ] [ 
+    ] [
         /// bar above the list
         if (getserver) [ sleep 0.1 [ updateservers ] ]
-        
+
         ui_list [
             ui_center_z [
                 ui_strut 0.5
-                
+
                 /// Reset List Button in red
                 ui_button (format "^fr%1" "Reset") clearservers
                 ui_strut 1.5
-                
+
                 /// Refresh List Button in green
                 ui_button (format "^fg%1" "Refresh") updatefrommaster
                 ui_strut 7.5
@@ -194,35 +224,35 @@ server_menu = [
             ]
 
         ]
-        
+
         // -- Sort Options -- //
         if $showserversortoptions [
             ui_bar
-            
+
             ui_list [
-                ui_center_z [ 
-                    ui_button "Reset" [serversortreset] [serversortreset] "" 0xFF8888 
+                ui_center_z [
+                    ui_button "Reset" [serversortreset] [serversortreset] "" 0xFF8888
                 ]
-                
+
                 ui_strut 1.5
-            
+
                 ui_center_z [
                     loop i (listlen $serversort) [
                         serverinfo_sort_type = (at $serversort $i)
                         if $serverinfo_sort_type [
-                        
+
                             serverinfo_sabsl = (? (> $serverinfo_sort_type 0) $serverinfo_sort_type (- 0 $serverinfo_sort_type))
                             serverinfo_server_name = (at $serverinfo_types $serverinfo_sabsl)
-                            
+
                             ui_big_spacer
-                            
-                            
+
+
                             ui_button (? (> $serverinfo_sort_type 0) $serverinfo_server_name [-@serverinfo_server_name]) [
                                 serverinfo_modify @serverinfo_sort_type
                             ] [
                                 serverinfo_modify (- 0 @serverinfo_sort_type)
                             ] "" 0x00FFFF
-                            
+
                             if (> (listlen $serversort) 1) [
                                 ui_strut 0.5
                                 ui_button (format "^fr%1" "x") [ remove_from_sort @serverinfo_sort_type ]
@@ -237,7 +267,7 @@ server_menu = [
                             if (&& $i [< (listfind serverinfo_client_type $serversort [= $i (? (> $serverinfo_client_type 0) $serverinfo_client_type (- 0 $serverinfo_client_type))]) 0]) [
                                 serverinfo_server_name = (at $serverinfo_types $i)
                                 ui_strut 1
-                                
+
                                 ui_button $serverinfo_server_name [
                                     serverinfo_modify @i
                                 ] [
@@ -252,19 +282,19 @@ server_menu = [
             ui_strut 0.25
             ui_list [
                 ui_checkbox (? $pausesortservers "^fdAuto Sort" "^fbAuto Sort") autosortservers // auto sort checkbox
-                
+
                 ui_strut 1.5
-                
+
                 // if auto sort is off, show sort now button
-                if $autosortservers [ ] [ 
+                if $autosortservers [ ] [
                     ui_button (format "^fy%1" "Sort Now") sortservers
                 ]
             ]
-            
+
             ui_bar
         ]
 
-        
+
 
         // if a new version is available, show a banner that holds a link where you can download it
         ui_small_spacer
@@ -329,7 +359,7 @@ server_menu = [
                     ui_font "emphasis" [ ui_button $title ]
 
                     // show ip and port
-                    ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ] 
+                    ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]
 
                     if $serverinfo_handle [
                         ui_font "little" [ ui_center [ ui_button (format "^fd[^fc%1^fd]" $serverinfo_handle) ] ]
@@ -344,7 +374,7 @@ server_menu = [
                     ]
                 ]
                 ui_spring 1
-                
+
                 // information beneigh the server title
                 if $serverinfo_active [
                     ui_list [
@@ -363,7 +393,7 @@ server_menu = [
                                 ui_button (format " ^fa  (%1modified^fa)" (? $serverinfo_modifications (format "^fc%1%% " (precf (*f (divf $serverinfo_modifications $serverinfo_variables) 100) 2)) "^faun"))
 
                                 // show server platform and branch
-                                if (&& ($serverbrowser_show_server_platform_and_branch) (>= $serverinfo_attribute 13)) [ 
+                                if (&& ($serverbrowser_show_server_platform_and_branch) (>= $serverinfo_attribute 13)) [
                                     ui_font "little" [ ui_center_z [
                                         ui_text (format " ^fa[^fa%1" $serverinfo_version_major)
                                         ui_text (format "^fa.%1" $serverinfo_version_minor)
@@ -421,7 +451,7 @@ server_menu = [
                     ]
                 ]
             ]
-        ] [ 
+        ] [
             serverinfo_password = ""
             serverinfo_retry = @(escape $serverinfo_name_port_id)
             serverinfo_wait = (! (|| [hasauthkey 1] [!= @@serverinfo_mstr 4]))
@@ -454,11 +484,11 @@ server_menu = [
 
         ui_list [
             ui_checkbox (format "^fc%1" "Search LAN") searchlan // search lan checkbox
-            
+
             ui_strut 1.5
-            
+
             ui_button (format "^fm%1" "LAN Connect") "savewarnchk lanconnect" // lan connect button
-            
+
             ui_strut 1.5
 
             ui_button (format "^fo%1" "Disconnect") "savewarnchk disconnect" // disconnect button

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -3399,33 +3399,8 @@ namespace client
 
     void getservers(int server, int prop, int idx)
     {
-        if(server < 0) 
+        if(server < 0)
         {
-            if (hideincompatibleservers)
-            {
-                vector<serverinfo *> servers_new;
-                for (int i = 0; i < servers.length(); i++)
-                {
-                    serverinfo* si = servers[i];
-                    // check that the server is compatible
-                    if (si->attr.inrange(0))
-                    {
-                        if (si->attr[0] == server::getver(1))
-                        {
-                            servers_new.add(servers[i]);
-                        }
-                    }
-                    else
-                    {
-                        if (client::serverstat(si) != 2)
-                        {
-                            servers_new.add(servers[i]);
-                        }
-                    }
-                }
-                servers = servers_new;
-            }
-
             intret(servers.length());
         }
         else if(servers.inrange(server))

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -18,7 +18,6 @@ namespace client
     VAR(IDF_PERSIST, showteamchange, 0, 1, 2); // 0 = never show, 1 = show only when switching between, 2 = show when entering match too
     VAR(IDF_PERSIST, showservervariables, 0, 0, 1); // determines if variables set by the server are printed to the console
     VAR(IDF_PERSIST, showmapvotes, 0, 1, 3); // shows map votes, 1 = only mid-game (not intermision), 2 = at all times, 3 = verbose
-    VAR(IDF_PERSIST, hideincompatibleservers, 0, 0, 1);
     VAR(IDF_PERSIST, playmentionedsound, 0, 0, 1);
 
     VAR(IDF_PERSIST, checkpointannounce, 0, 5, 7); // 0 = never, &1 = active players, &2 = all players, &4 = all players in gauntlet


### PR DESCRIPTION
The previous implementation was just a bit of a hack; this puts the filtering in CS with the rest of the filtering which reduces C++ complexity and allows for easier future updates.

Removes a memory leak in getservers(): `servers = servers_new;`.
Refractors and documents part of the server browser UI (removing ugly massive ternary *chains*).
Modifies displayed counts based on filtering: servers that aren't displayed aren't counted.

Replaces the variable with an alias to keep things in CubeScript (let me know if this is undesirable!)

Currently I have the usage description for hideincompatibleservers next to its definition, as that is possible in CubeScript, however it is entirely a matter of choice whether we should have CubeScript descriptions in usage.cfg as well. I'm fine either way.