### PR TITLE
Make serverbrowser search bar consistent with filtering.

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -14,6 +14,7 @@ serverinfo_players = 0
 serverinfo_servers = 0
 serverinfo_server_count = 0
 serverinfo_ui_time = 0
+serverinfo_search_str = ""
 
 spacing_between_serverinfos = 0.3
 
@@ -71,8 +72,6 @@ initialise_server_menu = [
     serverinfo_ui_time = (getmillis 1)
     shown_server_ui = 0
     update_server_ui = 0
-    search_filter = 1
-    search_str = ""
 ]
 server_menu_iterator = [
     if (! $shown_server_ui) [
@@ -143,7 +142,7 @@ server_menu = [
         ]
 
         // To display a server, it must be included in the search filter (if applicable) and protocol compatible (if applicable)
-        serverinfo_filter_include = (|| (= $search_filter 0)  (> (stringcasestr $search_buffer $search_str) -1))
+        serverinfo_filter_include = (|| (=s $serverinfo_search_str "") (> (stringcasestr $search_buffer $serverinfo_search_str) -1))
         serverinfo_filter_compatible = (|| (! $hideincompatibleservers) (= $serverinfo_game_version (getversion 1)))
         serverinfo_display = (&& $serverinfo_filter_include $serverinfo_filter_compatible)
 
@@ -215,7 +214,11 @@ server_menu = [
                 /// Search Bar
                 ui_text "Search: "
                 ui_strut 0.5
-                ui_textfield search_strval 40 [search_str = $search_strval; search_filter = 1; serverinfo_index = 0] -1 0 "" 0 "^fd <enter text>" 1
+                ui_textfield serverinfo_search_str 40 [serverinfo_index = 0] -1 0 "" 0 "^fd Search" 1
+
+                // Reset search button
+                ui_strut 0.5
+                ui_button "^frx" [ serverinfo_search_str = "" ]
             ]
             ui_spring 1
             /// show how many players are online on how many servers currently


### PR DESCRIPTION
Fixes the issue where the search bar would still display an inactive filter after re-opening the server browser.

Changes the placeholder text to match convention.
Adds a reset button to the filter to match other filter options.

This also prevents a clash with maps.cfg by renaming the search string to be within the serverinfo namespace and not relying on search_filter which is ALSO from maps.cfg (scope! scope! scope!)

This is an alternative PR: Closes #94

![2020-07-04-090732_698x67_scrot](https://user-images.githubusercontent.com/2333388/86513151-e53ec000-bdd5-11ea-9835-339a03a72605.png)
