### PR TITLE
Maps list improvements: better <random> and size display.

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -130,7 +130,7 @@ mapselection = [
                         ui_merge 30 [
                             if (! ($hidemappreviews)) [
                                 ui_image (? (= $mapcategory 2) $i (concatword "maps/" $i)) [] 1.5 1 "textures/emblem"
-                            ] [ 
+                            ] [
                                 ui_image "textures/emblem" [] 1.5 1
                             ]
                             ui_strut 1
@@ -177,7 +177,7 @@ mapselection = [
                                 ]
                             ]
                             if (= isonline 1) [    //only if online
-                                if (=s $guirollovername textures/warning) [                                
+                                if (=s $guirollovername textures/warning) [
                                     ui_tooltip (format "This map is not in the rotation^n%1s or higher can still vote for this map" (privnumbertotext $modelock))
                                 ]
                             ]
@@ -328,7 +328,7 @@ voteselection = [
             ui_checkbox "^fcDynamic sort" sortvotes; ui_strut 1.5
             ui_checkbox "^foCleanup list" cleanvotes; ui_strut 1.5
             ui_button   "^fyClear vote" clearvote
-            
+
             ui_spring
             ui_list [
                 ui_background $ui_color_textfield_background $ui_blend_textfield_background $ui_color_textfield_border $ui_blend_textfield_border
@@ -370,7 +370,7 @@ voteselection = [
                                             ui_center [ui_font "huge" [ui_button (concatword $votecolour $voteplayers) ]]
                                             ui_strut 0.3
                                             ui_list [
-                                                ui_center [ui_font "little" [ui_button (format "%1 vote%2" $votecolour (? (!= $voteplayers 1) "s") )]]                                        
+                                                ui_center [ui_font "little" [ui_button (format "%1 vote%2" $votecolour (? (!= $voteplayers 1) "s") )]]
                                                 ui_center [ui_font "default" [ui_button (format "%1 %2%%" $votecolour (precf (*f (divf 100 (playersonserv)) $voteplayers) 0)) ]]    //can set the precision if its possible i think no decimal looks best
                                             ]
                                         ]
@@ -406,7 +406,7 @@ voteselection = [
                                                 ui_font "reduced" [ui_button "^faNo current votes"]
                                             ]
                                         ]
-                                    ]                                    
+                                    ]
                                 ] [if (= @voteself 1) [ clearvote ] [ start @@votemap @@votemode @@votemuts ]] [] []
                             ]
                         ]
@@ -463,9 +463,9 @@ extraoptions = [
             ] [ ui_strut 3 ]
         ]
     ]
-    
+
     ui_strut 1
-    
+
     if (! (isonline)) [
         ui_list [
             ui_text "Server Type:"; ui_strut 0.5
@@ -729,9 +729,9 @@ newgui maps [ ui_stay_open [ octapaks [
             ] [
                 mapselection
             ]
-            
+
             ui_strut 0.5
-            
+
             ui_checkbox "Hide Map Previews" hidemappreviews 1 0
         ]
     ]

--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -479,7 +479,9 @@ extraoptions = [
 fillmaparray = [ octapaks [
     maplist = ""
     case $mapcategory 0 [
-        t_maplist = (getmaplist $chosenmode $chosenmuts $allowmaps)
+        // Construct the "available maps" list from only maps that work with the chosen game.
+        // The <random> special value will select from these maps as well, so it is included in this category.
+        t_maplist = (concat "<random>" (getmaplist $chosenmode $chosenmuts $allowmaps))
         maplist = (listdel $t_maplist $mapfavs)
         maplist = (concat (listdel $t_maplist $maplist) $maplist)
         t_maplist = ""
@@ -546,7 +548,6 @@ fillmaparray = [ octapaks [
             maplist = $t_maplist
         ]
     ]
-    maplist = (concat "<random>" $maplist)
     mapindex = (? (< (+ $mapindex 8) (listlen $maplist)) $mapindex (? (< (- (listlen $maplist) 8) 0) 0 (- (listlen $maplist) 8)))
 ]]
 

--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -144,7 +144,10 @@ mapselection = [
                                     ui_strut 25 1
                                 ] [
                                     ui_strut 0.5
-                                    ui_button "<Random>"
+                                    ui_button "<random>"
+                                    ui_font "little" [
+                                        ui_button "^f[0x808080]Any" []
+                                    ]
                                     ui_strut 28 1
                                 ]
                             ]

--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -178,7 +178,7 @@ mapselection = [
                                     ui_strut 25 (+f 1 $map_display_size_offset)
                                 ] [
                                     ui_strut 0.5
-                                    ui_button "<random>"
+                                    ui_button "Random"
                                     ui_font "little" [
                                         ui_button "^f[0x808080]Any" []
                                     ]

--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -136,12 +136,46 @@ mapselection = [
                             ui_strut 1
                             ui_list [
                                 if (!=s $i "<random>") [
-                                    ui_strut 0.5
-                                    ui_button (concatword (? ($isfav) "^fb" "") (truncate_string (? (= $mapcategory 2) (substring $i 5) $i) 29)) []
+                                    // The base name of the map.
+                                    map_base_name = (? (= $mapcategory 2) (substring $i 5) $i)
+
+                                    // Compile a list of the map's sizes, running through small, medium, and large variables.
+                                    map_display_sizes = ""
+                                    // Loop through descriptors of each size: <list variable> <display string>
+                                    looplist map_size_desc [ "smallmaps ^f[0x008000]Small" "mediummaps ^f[0x00C000]Medium" "largemaps ^f[0x00FF00]Large"] [
+                                        // If this map is in the list variable.
+                                        if (!= (indexof $(at $map_size_desc 0) $map_base_name) -1) [
+                                            // The display string. Unescaped to enable the formatting colors.
+                                            map_display_size = (unescape (at $map_size_desc 1))
+
+                                            // Add the unescaped display string to the sizes.
+                                            // Simply replace the list if it does not exist, otherwise concat.
+                                            if (=s $map_display_sizes "") [
+                                                map_display_sizes = $map_display_size
+                                            ] [
+                                                map_display_sizes = (concat $map_display_sizes $map_display_size)
+                                            ]
+                                        ]
+                                    ]
+
+                                    // Set the strut offset depending on if any sizes must be displayed.
+                                    if (=s $map_display_sizes "") [
+                                        map_display_size_offset = 0
+                                    ] [
+                                        map_display_size_offset = 0.25
+                                    ]
+                                    ui_strut (-f 0.5 $map_display_size_offset)
+                                    ui_button (concatword (? ($isfav) "^fb" "") (truncate_string $map_base_name 29)) []
                                     ui_font "little" [
                                         if (!= $mapcategory 2) [ui_button (getmapmodemuts $i) []] [ui_button "^f[0x808080]sauerbraten" []]
                                     ]
-                                    ui_strut 25 1
+                                    // Display sizes if available.
+                                    if (!=s $map_display_sizes "") [
+                                        ui_font "little" [
+                                            ui_button $map_display_sizes []
+                                        ]
+                                    ]
+                                    ui_strut 25 (+f 1 $map_display_size_offset)
                                 ] [
                                     ui_strut 0.5
                                     ui_button "<random>"


### PR DESCRIPTION
* Fixes display of `<random>` in demos list; now displays it with the "available maps" since those are what are selected from for random.
  * Notes that `<random>` works with any mode.
* Displays the map sizes (small, medium, large) if they are set in the size variables (`smallmaps mediummaps allowmaps`)

![2020-07-04-140640_472x663_scrot](https://user-images.githubusercontent.com/2333388/86518394-ca814100-bdff-11ea-8d12-7f843c824bb2.png)
