### PR TITLE
Refine Serverbrowser style

### DIFF
--- a/config/menus/glue.cfg
+++ b/config/menus/glue.cfg
@@ -169,38 +169,40 @@ ui_two = [
 
 ui_big_macro = [ ui_stay_open [
     ui_list [
-        if (> $numargs 9) arg10
+        if (> $numargs 10) arg11
         ui_list [
             [@[arg1]count] = $arg2
             [@[arg1]disp] = 0
             [@[arg1]list] = 0
             ui_list [
                 ui_strut (+ $arg3 2) 1
-                ui_background $ui_color_textfield_background $ui_blend_textfield_background $ui_color_textfield_border $ui_blend_textfield_border
-                ui_strut 0.25
+                if (= $arg7 1) [
+                    ui_background $ui_color_textfield_background $ui_blend_textfield_background $ui_color_textfield_border $ui_blend_textfield_border
+                    ui_strut 0.25
+                ]
                 if (arg5) [
                     [@[arg1]num] = $arg6
                     if (> $[@[arg1]num] 0) [
                         [@[arg1]index] = (min (max 0 (- $[@[arg1]num] $[@[arg1]count])) $[@[arg1]index]) //safeguard
                         loop i $[@[arg1]num] [
-                            arg7
-                            if (arg8) [
+                            arg8
+                            if (arg9) [
                                 if (&& (>= $i $[@[arg1]index]) (< $[@[arg1]list] $[@[arg1]count])) [
-                                    if (> $numargs 10) arg11
+                                    if (> $numargs 10) arg12
                                     [@[arg1]list] = (+ $[@[arg1]list] 1)
                                 ]
                                 [@[arg1]disp] = (+ $[@[arg1]disp] 1)
                             ]
                         ]
-                    ] [ui_strut (-f (*f $arg4 $arg2) 1); arg9; [@[arg1]list] = $arg2]
-                ] [ui_strut (-f (*f $arg4 $arg2) 1); arg9; [@[arg1]list] = $arg2]
+                    ] [ui_strut (-f (*f $arg4 $arg2) 1); arg10; [@[arg1]list] = $arg2]
+                ] [ui_strut (-f (*f $arg4 $arg2) 1); arg10; [@[arg1]list] = $arg2]
                 [@[arg1]alts] = (- $[@[arg1]count] $[@[arg1]list])
                 if (> $[@[arg1]alts] 0) [ui_strut (*f $[@[arg1]alts] $arg4)]
                 ui_strut 0.25
             ]
             ui_slider [@[arg1]index] 0 (max (- $[@[arg1]disp] $[@[arg1]count]) 0) [] 1 1
         ]
-        arg12
+        arg13
     ]
 ] ]
 

--- a/config/menus/glue.cfg
+++ b/config/menus/glue.cfg
@@ -167,46 +167,98 @@ ui_two = [
     ui_spring 1
 ]
 
+// arg1 = macro_prefix, arg2 = number of entries shown at once, arg3 = minimum width
+// arg4 = idk, arg5 = idk, arg6 = idk, arg7 = show background (bool), arg8 = code to be executed before every entry (unsure)
+// arg9 = requirement for entry to be shown in list, arg10 = entry above other entries, e.g. infopopdown or smth like that
+// arg11 = info bar above the actual list, arg12 = list entry code, arg13 = info bar beneigh the actual list
 ui_big_macro = [ ui_stay_open [
+    local top_info_bar
+    local list_entry
+    local bottom_info_bar
+    local entries_shown_at_once
+    local top_info_bar
+    local bottom_info_bar
+    local initialise_macro_vars
+    local show_background
+    local minimum_width
+    local entries_shown_at_once
+
+    entries_shown_at_once   = $arg2
+    minimum_width           = $arg3
+    show_background         = $arg7
+
+    initialise_macro_vars   = arg8
+    show_entry_requirement  = arg9
+    info_popdown_menu       = arg10
+    top_info_bar            = arg11
+    list_entry              = arg12
+    bottom_info_bar         = arg13
+
+    macro_num   = @[arg1]num
+    macro_count = @[arg1]count
+    macro_disp  = @[arg1]disp
+    macro_list  = @[arg1]list
+    macro_index = @[arg1]index
+    macro_alts  = @[arg1]alts
+
     ui_list [
-        if (> $numargs 10) arg11
+        // show top info bar
+        if (> $numargs 10) [@[top_info_bar]]
+
+        // draw list with slider
         ui_list [
-            [@[arg1]count] = $arg2
-            [@[arg1]disp] = 0
-            [@[arg1]list] = 0
+            @[macro_count] = $entries_shown_at_once
+            @[macro_disp]  = 0
+            @[macro_list]  = 0
+
             ui_list [
-                ui_strut (+ $arg3 2) 1
-                if (= $arg7 1) [
+                ui_strut (+ $minimum_width 2) 1
+
+                if $show_background [
                     ui_background $ui_color_textfield_background $ui_blend_textfield_background $ui_color_textfield_border $ui_blend_textfield_border
                     ui_strut 0.25
                 ]
+
                 if (arg5) [
-                    [@[arg1]num] = $arg6
-                    if (> $[@[arg1]num] 0) [
-                        [@[arg1]index] = (min (max 0 (- $[@[arg1]num] $[@[arg1]count])) $[@[arg1]index]) //safeguard
-                        loop i $[@[arg1]num] [
-                            arg8
-                            if (arg9) [
-                                if (&& (>= $i $[@[arg1]index]) (< $[@[arg1]list] $[@[arg1]count])) [
-                                    if (> $numargs 11) arg12
-                                    [@[arg1]list] = (+ $[@[arg1]list] 1)
+                    @[macro_num] = $arg6
+                    if (> $@[macro_num] 0) [
+                        @[macro_index] = (min (max 0 (- $@[macro_num] $@[macro_count])) $@[macro_index])
+                        loop i $@[macro_num] [
+                            [@[initialise_macro_vars]]
+
+                            if ([@[show_entry_requirement]]) [
+                                if (&& (>= $i $@[macro_index]) (< $@[macro_list] $@[macro_count])) [
+                                    if (> $numargs 11) [@[list_entry]]
+                                    @[macro_list] = (+ $@[macro_list] 1)
                                 ]
-                                [@[arg1]disp] = (+ $[@[arg1]disp] 1)
+                                @[macro_disp] = (+ $@[macro_disp] 1)
                             ]
                         ]
-                    ] [ui_strut (-f (*f $arg4 $arg2) 1); arg10; [@[arg1]list] = $arg2]
-                ] [ui_strut (-f (*f $arg4 $arg2) 1); arg10; [@[arg1]list] = $arg2]
-                [@[arg1]alts] = (- $[@[arg1]count] $[@[arg1]list])
-                if (> $[@[arg1]alts] 0) [ui_strut (*f $[@[arg1]alts] $arg4)]
-
-                if (= $arg7 1) [
-                    ui_strut 0.25
+                    ] [
+                        ui_strut (-f (*f $arg4 $entries_shown_at_once) 1)
+                        [@[info_popdown_menu]]
+                        @[macro_list] = $entries_shown_at_once
+                    ]
+                ] [
+                    ui_strut (-f (*f $arg4 $entries_shown_at_once) 1)
+                    [@[info_popdown_menu]]
+                    @[macro_list] = $entries_shown_at_once
                 ]
 
+                @[macro_alts] = (- $@[macro_count] $@[macro_list])
+                if (> $@[macro_alts] 0) [
+                    ui_strut (*f $@[macro_alts] $arg4)
+
+                    if $show_background [
+                        ui_strut 0.25
+                    ]
+                ]
             ]
-            ui_slider [@[arg1]index] 0 (max (- $[@[arg1]disp] $[@[arg1]count]) 0) [] 1 1
+            ui_slider @[macro_index] 0 (max (- $@[macro_disp] $@[macro_list]) 0) [] 1 1
         ]
-        arg13
+
+        // show bottom info bar
+        [@[bottom_info_bar]]
     ]
 ] ]
 

--- a/config/menus/glue.cfg
+++ b/config/menus/glue.cfg
@@ -15,7 +15,7 @@ ui_spacing = [
     ui_strut (divf $arg2 $fontheight)
 ]
 ui_spacing2 = [
-    ui_strut (divf $arg1 $fontwidth) 
+    ui_strut (divf $arg1 $fontwidth)
     ui_strut (divf $arg2 $fontheight) 1
 ]
 
@@ -28,7 +28,7 @@ ui_center_z = [ ui_list [ ui_spring 1; ui_list [ arg1 ]; ui_spring 1 ] ]
 ui_small_spacer = [ ui_strut 0.2 ]
 ui_big_spacer = [ ui_strut 0.8 ]
 
-ui_box = [ 
+ui_box = [
     ui_list [
         ui_background $arg1 $ui_blend_background $arg2 1 1
         ui_strut 0.8
@@ -105,25 +105,25 @@ ui_radiobutton2 = [
 ]
 
 // ui_button for editing commands with built-in key display, tooltip and r-click for console
-ui_edit_button = [ 
+ui_edit_button = [
     local cmd // in case there is a semicolon to escape
     cmd = (stringreplace $arg2 ";" "^";^"")
-    ui_body [     
+    ui_body [
         ui_button $arg1
         ui_strut 0.5
         ui_spring 1
-        ui_button (dobindsearch [@arg2] edit) 
+        ui_button (dobindsearch [@arg2] edit)
     ] [@arg2] [saycommand /@cmd] [ui_tooltip [/@@arg2]]
 ]
 ui_edit_button2 = [ui_list [ui_edit_button [@@arg1] [@@arg2]]]
 
 // same for looking up an editvarbind on a checkbox
 ui_edit_checbox = [
-    ui_body [     
+    ui_body [
         ui_checkbox $arg1 $arg2
         ui_strut 0.5
         ui_spring 1
-        ui_button (dobindsearch [@arg2 (= $@arg2 0); if (= $@arg2 0) [echo @@arg2 OFF] [ echo @@arg2 ON]] edit) 
+        ui_button (dobindsearch [@arg2 (= $@arg2 0); if (= $@arg2 0) [echo @@arg2 OFF] [ echo @@arg2 ON]] edit)
     ] [if (= $@arg2 0) [echo @@arg2 OFF] [ echo @@arg2 ON]] [saycommand /@arg2] [ui_tooltip [/@@arg2]]
 ]
 ui_edit_checbox2 = [ui_list [ui_edit_checbox [@@arg1] [@@arg2]]]
@@ -168,20 +168,20 @@ ui_two = [
 ]
 
 // arg1 = macro_prefix, arg2 = number of entries shown at once, arg3 = minimum width
-// arg4 = idk, arg5 = idk, arg6 = idk, arg7 = show background (bool), arg8 = code to be executed before every entry (unsure)
-// arg9 = requirement for entry to be shown in list, arg10 = entry above other entries, e.g. infopopdown or smth like that
+// arg4 = default spacing with no entries, arg5 = code test to display the list if this results true
+// arg6 = number of entries to be looped through, arg7 = show background (bool), arg8 = code to be executed before every entry
+// arg9 = requirement for entry to be shown in list, arg10 = to be shown when there's no entries
 // arg11 = info bar above the actual list, arg12 = list entry code, arg13 = info bar beneigh the actual list
 ui_big_macro = [ ui_stay_open [
+    local entries_shown_at_once
+    local minimum_width
+    local show_background
+    local initialise_macro_vars
+    local show_entry_requirement
+    local info_popdown_menu
     local top_info_bar
     local list_entry
     local bottom_info_bar
-    local entries_shown_at_once
-    local top_info_bar
-    local bottom_info_bar
-    local initialise_macro_vars
-    local show_background
-    local minimum_width
-    local entries_shown_at_once
 
     entries_shown_at_once   = $arg2
     minimum_width           = $arg3

--- a/config/menus/glue.cfg
+++ b/config/menus/glue.cfg
@@ -188,7 +188,7 @@ ui_big_macro = [ ui_stay_open [
                             arg8
                             if (arg9) [
                                 if (&& (>= $i $[@[arg1]index]) (< $[@[arg1]list] $[@[arg1]count])) [
-                                    if (> $numargs 10) arg12
+                                    if (> $numargs 11) arg12
                                     [@[arg1]list] = (+ $[@[arg1]list] 1)
                                 ]
                                 [@[arg1]disp] = (+ $[@[arg1]disp] 1)
@@ -198,7 +198,11 @@ ui_big_macro = [ ui_stay_open [
                 ] [ui_strut (-f (*f $arg4 $arg2) 1); arg10; [@[arg1]list] = $arg2]
                 [@[arg1]alts] = (- $[@[arg1]count] $[@[arg1]list])
                 if (> $[@[arg1]alts] 0) [ui_strut (*f $[@[arg1]alts] $arg4)]
-                ui_strut 0.25
+
+                if (= $arg7 1) [
+                    ui_strut 0.25
+                ]
+
             ]
             ui_slider [@[arg1]index] 0 (max (- $[@[arg1]disp] $[@[arg1]count]) 0) [] 1 1
         ]

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -392,7 +392,7 @@ server_menu = [
                         if (= $serverinfo_game_version (getversion 1)) [
 
                             if (!= $serverinfo_mode $modeidxediting) [
-                                ui_button (format " ^fd[^fc%1^fd:^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
+                                ui_button (format "^fd[^fc%1^fd: ^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
                             ]
                             gname = (gamename $serverinfo_mode $serverinfo_mutators 0 32)
                             ui_font "little" [ ui_center [ ui_list [

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -366,7 +366,7 @@ server_menu = [
                         title = (format "^fo%1" $serverinfo_title)
                     ]
 
-                    ui_font "emphasis" [ ui_button $title ]
+                    ui_font "emphasis" [ ui_button (limitstring $title 56) ]
 
                     // show ip and port
                     ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -204,22 +204,21 @@ server_menu = [
                 ui_strut 0.5
 
                 /// Reset List Button in red
-                ui_button (format "^fr%1" "Reset") clearservers
-                ui_strut 1.5
+                ui_button (format "^fr%1" "Reset") clearservers; ui_strut 1.5
 
                 /// Refresh List Button in green
-                ui_button (format "^fg%1" "Refresh") updatefrommaster
-                ui_strut 7.5
+                ui_button (format "^fg%1" "Refresh") updatefrommaster; ui_strut 7.5
 
                 /// Search Bar
-                ui_text "Search: "
-                ui_strut 0.5
-                ui_textfield serverinfo_search_str 40 [serverinfo_index = 0] -1 0 "" 0 "^fd Search" 1
-
-                // Reset search button
-                ui_strut 0.5
-                ui_button "^frx" [ serverinfo_search_str = "" ]
+                ui_text "Search: "; ui_strut 0.5
             ]
+            ui_textfield serverinfo_search_str 40 [serverinfo_index = 0] -1 0 "" 0 "^fd Search" 1; ui_strut 0.5
+
+            ui_center_z [
+                // Reset search button
+                ui_button "^frX" [ serverinfo_search_str = "" ]
+            ]
+
             ui_spring 1
             /// show how many players are online on how many servers currently
             ui_list [

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -20,6 +20,10 @@ spacing_between_serverinfos = 0.3
 
 number_of_servers_shown_at_once = 5
 
+serverfavs = ""
+setpersist serverfavs 1
+setcomplete serverfavs 1
+
 remove_from_sort = [
     serverinfo_type_list = ""
     serverinfo_tabsl = (? (> $serverinfo_type_list 0) $serverinfo_type_list (- 0 $serverinfo_type_list))
@@ -95,7 +99,7 @@ server_menu_iterator = [
 server_menu = [
     serverinfo_pause = 0
     serverinfo_timer = (- (getmillis 1) $serverinfo_ui_time)
-    ui_big_macro serverinfo_ $number_of_servers_shown_at_once 100 4 [getserver] (getserver) [
+    ui_big_macro serverinfo_ $number_of_servers_shown_at_once 95 4 [getserver] (getserver) [
         serverinfo_status         = (get_server_status $i)
         serverinfo_name           = (get_server_name $i)
         serverinfo_port           = (get_server_port $i)
@@ -315,189 +319,194 @@ server_menu = [
         ]
 
     ] [ // the actual list
-        ui_merge 88 [
+        ui_list [
             ui_background 0x222222
 
-            ui_center [
-                ui_strut 8 1
-                if $serverinfo_active [
-                    ui_center [
-                        ui_font "huge" [ ui_button (format "^fw%1" $serverinfo_player_count) ] // players playing
-                        ui_center [ ui_button (format "^fd/^fa%1" $serverinfo_max_players) ] // max players
-                    ]
-                    ui_strut 0.125
-                    ui_center [
-                        ui_button (format "^f%1%2" (? (< $serverinfo_ping 200) "g" (? (< $serverinfo_ping 400) "y" "r")) $serverinfo_ping) // ping info
-                        ui_font "little" [ ui_button " ^fams" ]
-                    ]
-                    ui_strut 0.125
-                    ui_center [
-                        serverinfo_seconds = (? (>= $serverinfo_last 0) (div (- (getmillis 1) $serverinfo_last) 1000) -1) // ??last ping info??
-                        ui_font "little" [ ui_button (? (>= $serverinfo_seconds 0) (format "^fa%1 ^fds ago" $serverinfo_seconds) "^fdwaiting..") ]
-                    ]
-                ] [ ui_center [ ui_font "huge" [ ui_button "?" ] ] ]
-            ]
-            // START OF SERVER INFORMATION LIST
-            serverinfo_image = "textures/emblem"
-            if (&& [< $serverinfo_ping $serverwaiting] [= $serverinfo_game_version (getversion 1)]) [
-                serverinfo_path = (listfind curmap $map_list [|| [=s $curmap $serverinfo_map_name] [=s [base/@curmap] $serverinfo_map_name] [
-                    && [> $hasoctapaks 0] [=s [base/@curmap] $serverinfo_map_name]
-                ]])
-                if (> $serverinfo_path -1) [ serverinfo_image = (at $map_path $serverinfo_path) ]
-            ]
-            ui_image $serverinfo_image "" 2 1 "textures/emblem" // display the server emblem
-            ui_strut 1
-
-            ui_list [
-                // make sure the entry takes all the horizontal space available
-                ui_list2 [ ui_strut 85 1 ]
+            ui_list [ ui_merge 88 [
+                ui_center [
+                    ui_strut 8 1
+                    if $serverinfo_active [
+                        ui_center [
+                            ui_font "huge" [ ui_button (format "^fw%1" $serverinfo_player_count) ] // players playing
+                            ui_center [ ui_button (format "^fd/^fa%1" $serverinfo_max_players) ] // max players
+                        ]
+                        ui_strut 0.125
+                        ui_center [
+                            ui_button (format "^f%1%2" (? (< $serverinfo_ping 200) "g" (? (< $serverinfo_ping 400) "y" "r")) $serverinfo_ping) // ping info
+                            ui_font "little" [ ui_button " ^fams" ]
+                        ]
+                        ui_strut 0.125
+                        ui_center [
+                            serverinfo_seconds = (? (>= $serverinfo_last 0) (div (- (getmillis 1) $serverinfo_last) 1000) -1) // ??last ping info??
+                            ui_font "little" [ ui_button (? (>= $serverinfo_seconds 0) (format "^fa%1 ^fds ago" $serverinfo_seconds) "^fdwaiting..") ]
+                        ]
+                    ] [ ui_center [ ui_font "huge" [ ui_button "?" ] ] ]
+                ]
+                // START OF SERVER INFORMATION LIST
+                serverinfo_image = "textures/emblem"
+                if (&& [< $serverinfo_ping $serverwaiting] [= $serverinfo_game_version (getversion 1)]) [
+                    serverinfo_path = (listfind curmap $map_list [|| [=s $curmap $serverinfo_map_name] [=s [base/@curmap] $serverinfo_map_name] [
+                        && [> $hasoctapaks 0] [=s [base/@curmap] $serverinfo_map_name]
+                    ]])
+                    if (> $serverinfo_path -1) [ serverinfo_image = (at $map_path $serverinfo_path) ]
+                ]
+                ui_image $serverinfo_image "" 2 1 "textures/emblem" // display the server emblem
+                ui_strut 1
 
                 ui_list [
-                    ui_list [ ui_strut 4 ]
-                    ui_center [
-                        ui_list [
-                            // Server title
-                            title = (format "^fw%1" $serverinfo_title)
+                    // make sure the entry takes all the horizontal space available
+                    ui_list2 [ ui_strut 80 1 ]
 
-                            if (= $serverinfo_game_version (getversion 1)) [
-                                case $serverinfo_status 0 [
-                                    title = (format "^fw%1" $serverinfo_title)
-                                ] 1 [
-                                    title = (format "^fy%1" $serverinfo_title)
-                                ] 2 [
-                                    title = (format "^fm%1" $serverinfo_title)
-                                ] 3 [ // Server Incompatible
-                                    title = (format "^fo%1" $serverinfo_title)
-                                ] () [
-                                    title = (format "^fa%1" $serverinfo_title)
-                                ]
-                            ] [
-                                title = (format "^fo%1" $serverinfo_title)
-                            ]
-
-                            ui_font "emphasis" [ ui_button (limitstring $title 64) ]
-
-                            // show ip and port
-                            ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]
-
-                            if $serverinfo_handle [
-                                ui_font "little" [ ui_center [ ui_button (format "^fd[^fc%1^fd]" $serverinfo_handle) ] ]
-                            ]
-                            if $serverinfo_status_flag [
-                                ui_font "little" [ ui_center [ ui_button "^fd[^fcstatistics^fd]" ] ]
-                            ]
-
-                            // if enabled, show priority
-                            if $showserverpriority [
-                                ui_font "little" [ ui_center [ ui_button (format "^fd[^fcpriority %1^fd]" $serverinfo_priority) ] ]
-                            ]
-                        ]
-                        ui_spring 1
-
-                        // information beneigh the server title
-                        if $serverinfo_active [
+                    ui_list [
+                        ui_list [ ui_strut 4 ]
+                        ui_center [
                             ui_list [
-                                ui_small_spacer
+                                // Server title
+                                title = (format "^fw%1" $serverinfo_title)
+
                                 if (= $serverinfo_game_version (getversion 1)) [
-
-                                    if (!= $serverinfo_mode $modeidxediting) [
-                                        ui_button (format "^fd[^fc%1^fd: ^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
+                                    case $serverinfo_status 0 [
+                                        title = (format "^fw%1" $serverinfo_title)
+                                    ] 1 [
+                                        title = (format "^fy%1" $serverinfo_title)
+                                    ] 2 [
+                                        title = (format "^fm%1" $serverinfo_title)
+                                    ] 3 [ // Server Incompatible
+                                        title = (format "^fo%1" $serverinfo_title)
+                                    ] () [
+                                        title = (format "^fa%1" $serverinfo_title)
                                     ]
-                                    gname = (gamename $serverinfo_mode $serverinfo_mutators 0 32)
-                                    ui_font "little" [ ui_center [ ui_list [
-                                        // show map name
-                                        ui_button (format " ^fy%1 ^faon ^fo%2" $gname $serverinfo_map_name)
-
-                                        // show how modified the server is
-                                        ui_button (format " ^fa  (%1modified^fa)" (? $serverinfo_modifications (format "^fc%1%% " (precf (*f (divf $serverinfo_modifications $serverinfo_variables) 100) 2)) "^faun"))
-
-                                        // show server platform and branch
-                                        if (&& ($serverbrowser_show_server_platform_and_branch) (>= $serverinfo_attribute 13)) [
-                                            ui_font "little" [ ui_center_z [
-                                                ui_text (format " ^fa[^fa%1" $serverinfo_version_major)
-                                                ui_text (format "^fa.%1" $serverinfo_version_minor)
-                                                ui_text (format "^fa.%1" $serverinfo_version_patch)
-                                                ui_text (format "^fa-%1" (platname $serverinfo_version_server) )
-                                                ui_text (format "^fa%1" $serverinfo_version_a)
-                                                if $serverinfo_branch [
-                                                    ui_text (format "^fa-%1^fa]" $serverinfo_branch)
-                                                ] [
-                                                    ui_text "^fa]"
-                                                ]
-                                            ] ]
-                                        ]
-                                    ] ] ]
                                 ] [
-                                    ui_no_hit_fx [ ui_font "default" [ ui_button "^foIncompatible" [] [] "textures/servers/failed" ] ]
-                                    ui_button (concat " ^faServer is using" (? (> $serverinfo_game_version (getversion 1)) "a ^fwnewer" "an ^fdolder") "protocol")
+                                    title = (format "^fo%1" $serverinfo_title)
+                                ]
+
+                                ui_font "emphasis" [ ui_button (limitstring $title 64) ]
+
+                                // show ip and port
+                                ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]
+
+                                if $serverinfo_handle [
+                                    ui_font "little" [ ui_center [ ui_button (format "^fd[^fc%1^fd]" $serverinfo_handle) ] ]
+                                ]
+                                if $serverinfo_status_flag [
+                                    ui_font "little" [ ui_center [ ui_button "^fd[^fcstatistics^fd]" ] ]
+                                ]
+
+                                // if enabled, show priority
+                                if $showserverpriority [
+                                    ui_font "little" [ ui_center [ ui_button (format "^fd[^fcpriority %1^fd]" $serverinfo_priority) ] ]
                                 ]
                             ]
                             ui_spring 1
-                            // display password field
-                            ui_list [
-                                if (=s $serverinfo_name_port_id $serverinfo_retry) [
-                                    if (= $serverinfo_status 3) [ ui_button "^fd[ ^fwWaiting for slot ^fd] " ]
-                                    ui_button "^fwPassword ^fd= "
-                                    serverinfo_passwordval = $serverinfo_password
-                                    ui_textfield serverinfo_passwordval 20 [serverinfo_password = $serverinfo_passwordval]
-                                ] [
-                                    if (> $serverinfo_player_count 0) [
-                                        ui_small_spacer
-                                        serverinfo_player_count = (getserver $i 2)
-                                        if (> $serverinfo_player_count 0) [
-                                            ui_font "little" [
-                                                pname = ""
-                                                plist = ""
-                                                pmore = 0
-                                                loop j $serverinfo_player_count [
-                                                    if (|| $pmore (>= (ui_text_width $plist) 1400)) [ pmore = (+ $pmore 1) ] [
-                                                        append pname (format ["%1"] (getserver $i 2 $j))
-                                                        plist = (prettylist $pname)
+
+                            // information beneigh the server title
+                            if $serverinfo_active [
+                                ui_list [
+                                    ui_small_spacer
+                                    if (= $serverinfo_game_version (getversion 1)) [
+
+                                        if (!= $serverinfo_mode $modeidxediting) [
+                                            ui_button (format "^fd[^fc%1^fd: ^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
+                                        ]
+                                        gname = (gamename $serverinfo_mode $serverinfo_mutators 0 32)
+                                        ui_font "little" [ ui_center [ ui_list [
+                                            // show map name
+                                            ui_button (format " ^fy%1 ^faon ^fo%2" $gname $serverinfo_map_name)
+
+                                            // show how modified the server is
+                                            ui_button (format " ^fa  (%1modified^fa)" (? $serverinfo_modifications (format "^fc%1%% " (precf (*f (divf $serverinfo_modifications $serverinfo_variables) 100) 2)) "^faun"))
+
+                                            // show server platform and branch
+                                            if (&& ($serverbrowser_show_server_platform_and_branch) (>= $serverinfo_attribute 13)) [
+                                                ui_font "little" [ ui_center_z [
+                                                    ui_text (format " ^fa[^fa%1" $serverinfo_version_major)
+                                                    ui_text (format "^fa.%1" $serverinfo_version_minor)
+                                                    ui_text (format "^fa.%1" $serverinfo_version_patch)
+                                                    ui_text (format "^fa-%1" (platname $serverinfo_version_server) )
+                                                    ui_text (format "^fa%1" $serverinfo_version_a)
+                                                    if $serverinfo_branch [
+                                                        ui_text (format "^fa-%1^fa]" $serverinfo_branch)
+                                                    ] [
+                                                        ui_text "^fa]"
                                                     ]
-                                                ]
-                                                ui_button (concat $plist (? $pmore (concat "and^fy" $pmore "^fwmore")))
-                                                //[] [] "" -1 -1 1900
+                                                ] ]
                                             ]
-                                        ] [ ui_button "^faPlayer info not available" ]
-                                    ] [ ui_button "^faNo players online" ]
+                                        ] ] ]
+                                    ] [
+                                        ui_no_hit_fx [ ui_font "default" [ ui_button "^foIncompatible" [] [] "textures/servers/failed" ] ]
+                                        ui_button (concat " ^faServer is using" (? (> $serverinfo_game_version (getversion 1)) "a ^fwnewer" "an ^fdolder") "protocol")
+                                    ]
                                 ]
-                            ]
-                        ] [
-                            ui_list [
-                                ui_small_spacer
-                                ui_font "default" [ ui_button "^foUnresponsive" [] [] "textures/servers/failed" ]
-                                ui_button " ^faServer is not replying to queries"
+                                ui_spring 1
+                                // display password field
+                                ui_list [
+                                    if (=s $serverinfo_name_port_id $serverinfo_retry) [
+                                        if (= $serverinfo_status 3) [ ui_button "^fd[ ^fwWaiting for slot ^fd] " ]
+                                        ui_button "^fwPassword ^fd= "
+                                        serverinfo_passwordval = $serverinfo_password
+                                        ui_textfield serverinfo_passwordval 20 [serverinfo_password = $serverinfo_passwordval]
+                                    ] [
+                                        if (> $serverinfo_player_count 0) [
+                                            ui_small_spacer
+                                            serverinfo_player_count = (getserver $i 2)
+                                            if (> $serverinfo_player_count 0) [
+                                                ui_font "little" [
+                                                    pname = ""
+                                                    plist = ""
+                                                    pmore = 0
+                                                    loop j $serverinfo_player_count [
+                                                        if (|| $pmore (>= (ui_text_width $plist) 1400)) [ pmore = (+ $pmore 1) ] [
+                                                            append pname (format ["%1"] (getserver $i 2 $j))
+                                                            plist = (prettylist $pname)
+                                                        ]
+                                                    ]
+                                                    ui_button (concat $plist (? $pmore (concat "and^fy" $pmore "^fwmore")))
+                                                    //[] [] "" -1 -1 1900
+                                                ]
+                                            ] [ ui_button "^faPlayer info not available" ]
+                                        ] [ ui_button "^faNo players online" ]
+                                    ]
+                                ]
+                            ] [
+                                ui_list [
+                                    ui_small_spacer
+                                    ui_font "default" [ ui_button "^foUnresponsive" [] [] "textures/servers/failed" ]
+                                    ui_button " ^faServer is not replying to queries"
+                                ]
                             ]
                         ]
                     ]
                 ]
-            ]
-        ] [
-            serverinfo_password = ""
-            serverinfo_retry = @(escape $serverinfo_name_port_id)
-            serverinfo_wait = (! (|| [hasauthkey 1] [!= @@serverinfo_mstr 4]))
-        ] [
-            serverinfo_password = ""
-            serverinfo_retry = @(escape $serverinfo_name_port_id)
-            serverinfo_wait = (! (hasauthkey 1))
-        ] [
-            serverinfo_pause = 1
-            if $serverinfo_active [
-                serverinfo_player_count = (getserver $i 2)
-                if (> $serverinfo_player_count 0) [
-                    phover = ""
-                    loop j $serverinfo_player_count [
-                        if $j [ append phover "^n" ]
-                        phandle = (getserver $i 3 $j)
-                        if (stringlen $phandle) [
-                            append phover (format "%1 (%2)" (getserver $i 2 $j) $phandle)
-                        ] [
-                            append phover (format "%1" (getserver $i 2 $j))
+            ] [
+                serverinfo_password = ""
+                serverinfo_retry = @(escape $serverinfo_name_port_id)
+                serverinfo_wait = (! (|| [hasauthkey 1] [!= @@serverinfo_mstr 4]))
+            ] [
+                serverinfo_password = ""
+                serverinfo_retry = @(escape $serverinfo_name_port_id)
+                serverinfo_wait = (! (hasauthkey 1))
+            ] [
+                serverinfo_pause = 1
+                if $serverinfo_active [
+                    serverinfo_player_count = (getserver $i 2)
+                    if (> $serverinfo_player_count 0) [
+                        phover = ""
+                        loop j $serverinfo_player_count [
+                            if $j [ append phover "^n" ]
+                            phandle = (getserver $i 3 $j)
+                            if (stringlen $phandle) [
+                                append phover (format "%1 (%2)" (getserver $i 2 $j) $phandle)
+                            ] [
+                                append phover (format "%1" (getserver $i 2 $j))
+                            ]
                         ]
-                    ]
-                    ui_tooltip $phover
-                ] [ ui_tooltip "^faNo players online" ]
-            ] [ ui_tooltip "^faNo information available" ]
+                        ui_tooltip $phover
+                    ] [ ui_tooltip "^faNo players online" ]
+                ] [ ui_tooltip "^faNo information available" ]
+            ] ]
+            ui_center_z [
+                ui_image "textures/icons/fontawesome/graphics" [ echo "testacle" ] 0.75 0 "" [] 0x6666ff
+            ]; ui_strut 1
         ]
         ui_strut $spacing_between_serverinfos
     ] [ // bar beneigh the list

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -501,7 +501,7 @@ server_menu = [
         ]
         ui_strut $spacing_between_serverinfos
     ] [ // bar beneigh the list
-        ui_big_spacer
+        ui_strut 0.5
 
         ui_list [
             ui_checkbox (format "^fc%1" "Search LAN")  searchlan;                 ui_strut 1.5

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -316,7 +316,7 @@ server_menu = [
 
     ] [ // the actual list
         ui_merge 88 [
-            ui_background 0x444444
+            ui_background 0x222222
 
             ui_center [
                 ui_strut 8 1

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -502,9 +502,10 @@ server_menu = [
                     ] [ ui_tooltip "^faNo players online" ]
                 ] [ ui_tooltip "^faNo information available" ]
             ] ]
-            ui_center_z [
-                ui_image "textures/icons/fontawesome/favourite_off" [ echo "Coming Soon!" ] 0.75
-            ]; ui_strut 1
+            //ui_center_z [
+            //    ui_image "textures/icons/fontawesome/favourite_off" [ echo "Coming Soon!" ] 0.75
+            //]; ui_strut 1
+            ui_strut 5
         ]
     ] [ // bar beneigh the list
         ui_strut 0.5

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -207,11 +207,10 @@ server_menu = [
                 ui_button (format "^fr%1" "Reset") clearservers; ui_strut 1.5
 
                 /// Refresh List Button in green
-                ui_button (format "^fg%1" "Refresh") updatefrommaster; ui_strut 7.5
+                ui_button (format "^fg%1" "Refresh") updatefrommaster; ui_strut 15
 
-                /// Search Bar
-                ui_text "Search: "; ui_strut 0.5
             ]
+            // Search bar
             ui_textfield serverinfo_search_str 40 [serverinfo_index = 0] -1 0 "" 0 "^fd Search" 1; ui_strut 0.5
 
             ui_center_z [

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -375,7 +375,7 @@ server_menu = [
                                 title = (format "^fo%1" $serverinfo_title)
                             ]
 
-                            ui_font "emphasis" [ ui_button (limitstring $title 56) ]
+                            ui_font "emphasis" [ ui_button (limitstring $title 64) ]
 
                             // show ip and port
                             ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -99,7 +99,7 @@ server_menu_iterator = [
 server_menu = [
     serverinfo_pause = 0
     serverinfo_timer = (- (getmillis 1) $serverinfo_ui_time)
-    ui_big_macro serverinfo_ $number_of_servers_shown_at_once 95 4 [getserver] (getserver) [
+    ui_big_macro serverinfo_ $number_of_servers_shown_at_once 99.5 4 [getserver] (getserver) 0 [
         serverinfo_status         = (get_server_status $i)
         serverinfo_name           = (get_server_name $i)
         serverinfo_port           = (get_server_port $i)

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -504,27 +504,18 @@ server_menu = [
         ui_big_spacer
 
         ui_list [
-            ui_checkbox (format "^fc%1" "Search LAN") searchlan // search lan checkbox
+            ui_checkbox (format "^fc%1" "Search LAN")  searchlan;                 ui_strut 1.5
+            ui_button   (format "^fm%1" "LAN Connect") "savewarnchk lanconnect";  ui_strut 1.5
+            ui_button   (format "^fo%1" "Disconnect")  "savewarnchk disconnect";  ui_spring 1
 
-            ui_strut 1.5
-
-            ui_button (format "^fm%1" "LAN Connect") "savewarnchk lanconnect" // lan connect button
-
-            ui_strut 1.5
-
-            ui_button (format "^fo%1" "Disconnect") "savewarnchk disconnect" // disconnect button
-        ]
-
-        ui_big_spacer
-        if (hasauthkey) [
-            ui_list [
-                ui_center_z [ ui_text "User Account:" ]
-                ui_spring 1
-                ui_center_z [ ui_checkbox (format "Identify as ^fs^fc%1^fS on connect" $accountname) authconnect ]
-                ui_spring 1
-                ui_center_z [ ui_font "little" [ ui_button "(^fs^frEdit Account^fS)" [show_ui profile 4] ] ]
+            if (hasauthkey) [
+                ui_checkbox (format "Identify as ^fs^fc%1^fS on connect" $accountname) authconnect; ui_strut 1.5
+                ui_center_z [ ui_font "little" [
+                    ui_button "(^fs^frEdit Account^fS)" [show_ui profile 4]
+                ] ]
             ]
         ]
+
     ]
     if (&& [! $guilayoutpass] [|| (> $serverinfo_timer 30000) (> $serverinfo_server_count (div (* $server_count 3) 4))]) [ if $serverinfo_pause [ if (! $pausesortservers) [ pausesortservers 1 ] ] [ if $pausesortservers [ pausesortservers 0 ] ] ]
 

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -519,6 +519,7 @@ server_menu = [
 ]
 
 new_ui Servers [
+    ui_header "Serverbrowser"
     server_menu_iterator
     ui_list [ server_menu ]
 ] [

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -505,7 +505,7 @@ server_menu = [
                 ] [ ui_tooltip "^faNo information available" ]
             ] ]
             ui_center_z [
-                ui_image "textures/icons/fontawesome/graphics" [ echo "testacle" ] 0.75 0 "" [] 0x6666ff
+                ui_image "textures/icons/fontawesome/favourite_off" [ echo "Coming Soon!" ] 0.75
             ]; ui_strut 1
         ]
         ui_strut $spacing_between_serverinfos

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -215,7 +215,11 @@ server_menu = [
 
             ui_center_z [
                 // Reset search button
-                ui_button "^frX" [ serverinfo_search_str = "" ]
+                if (!=s $serverinfo_search_str "") [
+                    ui_button "^frX" [ serverinfo_search_str = "" ]
+                ] [
+                    ui_strut 1
+                ]
             ]
 
             ui_spring 1

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -349,9 +349,9 @@ server_menu = [
             ui_strut 1
 
             ui_list [
-                ui_list2 [
-                   ui_strut 85 1
-                ]
+                // make sure the entry takes all the horizontal space available
+                ui_list2 [ ui_strut 85 1 ]
+
                 ui_list [
                     ui_list [ ui_strut 4 ]
                     ui_center [

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -16,8 +16,6 @@ serverinfo_server_count = 0
 serverinfo_ui_time = 0
 serverinfo_search_str = ""
 
-spacing_between_serverinfos = 0.3
-
 number_of_servers_shown_at_once = 5
 
 serverfavs = ""
@@ -508,7 +506,6 @@ server_menu = [
                 ui_image "textures/icons/fontawesome/favourite_off" [ echo "Coming Soon!" ] 0.75
             ]; ui_strut 1
         ]
-        ui_strut $spacing_between_serverinfos
     ] [ // bar beneigh the list
         ui_strut 0.5
 

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -210,6 +210,7 @@ server_menu = [
                 ui_button (format "^fg%1" "Refresh") updatefrommaster; ui_strut 15
 
             ]
+
             // Search bar
             ui_textfield serverinfo_search_str 40 [serverinfo_index = 0] -1 0 "" 0 "^fd Search" 1; ui_strut 0.5
 
@@ -315,6 +316,8 @@ server_menu = [
 
     ] [ // the actual list
         ui_merge 88 [
+            ui_background 0x444444
+
             ui_center [
                 ui_strut 8 1
                 if $serverinfo_active [
@@ -344,120 +347,128 @@ server_menu = [
             ]
             ui_image $serverinfo_image "" 2 1 "textures/emblem" // display the server emblem
             ui_strut 1
-            ui_center [
-                ui_list [
-                    // Server title
 
-                    title = (format "^fw%1" $serverinfo_title)
-
-                    if (= $serverinfo_game_version (getversion 1)) [
-                        case $serverinfo_status 0 [
-                            title = (format "^fw%1" $serverinfo_title)
-                        ] 1 [
-                            title = (format "^fy%1" $serverinfo_title)
-                        ] 2 [
-                            title = (format "^fm%1" $serverinfo_title)
-                        ] 3 [ // Server Incompatible
-                            title = (format "^fo%1" $serverinfo_title)
-                        ] () [
-                            title = (format "^fa%1" $serverinfo_title)
-                        ]
-                    ] [
-                        title = (format "^fo%1" $serverinfo_title)
-                    ]
-
-                    ui_font "emphasis" [ ui_button (limitstring $title 56) ]
-
-                    // show ip and port
-                    ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]
-
-                    if $serverinfo_handle [
-                        ui_font "little" [ ui_center [ ui_button (format "^fd[^fc%1^fd]" $serverinfo_handle) ] ]
-                    ]
-                    if $serverinfo_status_flag [
-                        ui_font "little" [ ui_center [ ui_button "^fd[^fcstatistics^fd]" ] ]
-                    ]
-
-                    // if enabled, show priority
-                    if $showserverpriority [
-                        ui_font "little" [ ui_center [ ui_button (format "^fd[^fcpriority %1^fd]" $serverinfo_priority) ] ]
-                    ]
+            ui_list [
+                ui_list2 [
+                   ui_strut 85 1
                 ]
-                ui_spring 1
+                ui_list [
+                    ui_list [ ui_strut 4 ]
+                    ui_center [
+                        ui_list [
+                            // Server title
+                            title = (format "^fw%1" $serverinfo_title)
 
-                // information beneigh the server title
-                if $serverinfo_active [
-                    ui_list [
-                        ui_small_spacer
-                        if (= $serverinfo_game_version (getversion 1)) [
-
-                            if (!= $serverinfo_mode $modeidxediting) [
-                                ui_button (format "^fd[^fc%1^fd: ^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
-                            ]
-                            gname = (gamename $serverinfo_mode $serverinfo_mutators 0 32)
-                            ui_font "little" [ ui_center [ ui_list [
-                                // show map name
-                                ui_button (format " ^fy%1 ^faon ^fo%2" $gname $serverinfo_map_name)
-
-                                // show how modified the server is
-                                ui_button (format " ^fa  (%1modified^fa)" (? $serverinfo_modifications (format "^fc%1%% " (precf (*f (divf $serverinfo_modifications $serverinfo_variables) 100) 2)) "^faun"))
-
-                                // show server platform and branch
-                                if (&& ($serverbrowser_show_server_platform_and_branch) (>= $serverinfo_attribute 13)) [
-                                    ui_font "little" [ ui_center_z [
-                                        ui_text (format " ^fa[^fa%1" $serverinfo_version_major)
-                                        ui_text (format "^fa.%1" $serverinfo_version_minor)
-                                        ui_text (format "^fa.%1" $serverinfo_version_patch)
-                                        ui_text (format "^fa-%1" (platname $serverinfo_version_server) )
-                                        ui_text (format "^fa%1" $serverinfo_version_a)
-                                        if $serverinfo_branch [
-                                            ui_text (format "^fa-%1^fa]" $serverinfo_branch)
-                                        ] [
-                                            ui_text "^fa]"
-                                        ]
-                                    ] ]
+                            if (= $serverinfo_game_version (getversion 1)) [
+                                case $serverinfo_status 0 [
+                                    title = (format "^fw%1" $serverinfo_title)
+                                ] 1 [
+                                    title = (format "^fy%1" $serverinfo_title)
+                                ] 2 [
+                                    title = (format "^fm%1" $serverinfo_title)
+                                ] 3 [ // Server Incompatible
+                                    title = (format "^fo%1" $serverinfo_title)
+                                ] () [
+                                    title = (format "^fa%1" $serverinfo_title)
                                 ]
-                            ] ] ]
-                        ] [
-                            ui_no_hit_fx [ ui_font "default" [ ui_button "^foIncompatible" [] [] "textures/servers/failed" ] ]
-                            ui_button (concat " ^faServer is using" (? (> $serverinfo_game_version (getversion 1)) "a ^fwnewer" "an ^fdolder") "protocol")
+                            ] [
+                                title = (format "^fo%1" $serverinfo_title)
+                            ]
+
+                            ui_font "emphasis" [ ui_button (limitstring $title 56) ]
+
+                            // show ip and port
+                            ui_font "little" [ ui_center_z [ ui_button (format "^fd^fa %1^fd" $serverinfo_name_port_id) ] ]
+
+                            if $serverinfo_handle [
+                                ui_font "little" [ ui_center [ ui_button (format "^fd[^fc%1^fd]" $serverinfo_handle) ] ]
+                            ]
+                            if $serverinfo_status_flag [
+                                ui_font "little" [ ui_center [ ui_button "^fd[^fcstatistics^fd]" ] ]
+                            ]
+
+                            // if enabled, show priority
+                            if $showserverpriority [
+                                ui_font "little" [ ui_center [ ui_button (format "^fd[^fcpriority %1^fd]" $serverinfo_priority) ] ]
+                            ]
                         ]
-                    ]
-                    ui_spring 1
-                    // display password field
-                    ui_list [
-                        if (=s $serverinfo_name_port_id $serverinfo_retry) [
-                            if (= $serverinfo_status 3) [ ui_button "^fd[ ^fwWaiting for slot ^fd] " ]
-                            ui_button "^fwPassword ^fd= "
-                            serverinfo_passwordval = $serverinfo_password
-                            ui_textfield serverinfo_passwordval 20 [serverinfo_password = $serverinfo_passwordval]
-                        ] [
-                            if (> $serverinfo_player_count 0) [
+                        ui_spring 1
+
+                        // information beneigh the server title
+                        if $serverinfo_active [
+                            ui_list [
                                 ui_small_spacer
-                                serverinfo_player_count = (getserver $i 2)
-                                if (> $serverinfo_player_count 0) [
-                                    ui_font "little" [
-                                        pname = ""
-                                        plist = ""
-                                        pmore = 0
-                                        loop j $serverinfo_player_count [
-                                            if (|| $pmore (>= (ui_text_width $plist) 1400)) [ pmore = (+ $pmore 1) ] [
-                                                append pname (format ["%1"] (getserver $i 2 $j))
-                                                plist = (prettylist $pname)
-                                            ]
-                                        ]
-                                        ui_button (concat $plist (? $pmore (concat "and^fy" $pmore "^fwmore")))
-                                        //[] [] "" -1 -1 1900
+                                if (= $serverinfo_game_version (getversion 1)) [
+
+                                    if (!= $serverinfo_mode $modeidxediting) [
+                                        ui_button (format "^fd[^fc%1^fd: ^fw%2^fd]" (at $gamestatename $serverinfo_game_st) (timestr (* (? $serverinfo_player_count (max (- $serverinfo_game_tl $serverinfo_offline_time) 0) $serverinfo_time) 1000) 3))
                                     ]
-                                ] [ ui_button "^faPlayer info not available" ]
-                            ] [ ui_button "^faNo players online" ]
+                                    gname = (gamename $serverinfo_mode $serverinfo_mutators 0 32)
+                                    ui_font "little" [ ui_center [ ui_list [
+                                        // show map name
+                                        ui_button (format " ^fy%1 ^faon ^fo%2" $gname $serverinfo_map_name)
+
+                                        // show how modified the server is
+                                        ui_button (format " ^fa  (%1modified^fa)" (? $serverinfo_modifications (format "^fc%1%% " (precf (*f (divf $serverinfo_modifications $serverinfo_variables) 100) 2)) "^faun"))
+
+                                        // show server platform and branch
+                                        if (&& ($serverbrowser_show_server_platform_and_branch) (>= $serverinfo_attribute 13)) [
+                                            ui_font "little" [ ui_center_z [
+                                                ui_text (format " ^fa[^fa%1" $serverinfo_version_major)
+                                                ui_text (format "^fa.%1" $serverinfo_version_minor)
+                                                ui_text (format "^fa.%1" $serverinfo_version_patch)
+                                                ui_text (format "^fa-%1" (platname $serverinfo_version_server) )
+                                                ui_text (format "^fa%1" $serverinfo_version_a)
+                                                if $serverinfo_branch [
+                                                    ui_text (format "^fa-%1^fa]" $serverinfo_branch)
+                                                ] [
+                                                    ui_text "^fa]"
+                                                ]
+                                            ] ]
+                                        ]
+                                    ] ] ]
+                                ] [
+                                    ui_no_hit_fx [ ui_font "default" [ ui_button "^foIncompatible" [] [] "textures/servers/failed" ] ]
+                                    ui_button (concat " ^faServer is using" (? (> $serverinfo_game_version (getversion 1)) "a ^fwnewer" "an ^fdolder") "protocol")
+                                ]
+                            ]
+                            ui_spring 1
+                            // display password field
+                            ui_list [
+                                if (=s $serverinfo_name_port_id $serverinfo_retry) [
+                                    if (= $serverinfo_status 3) [ ui_button "^fd[ ^fwWaiting for slot ^fd] " ]
+                                    ui_button "^fwPassword ^fd= "
+                                    serverinfo_passwordval = $serverinfo_password
+                                    ui_textfield serverinfo_passwordval 20 [serverinfo_password = $serverinfo_passwordval]
+                                ] [
+                                    if (> $serverinfo_player_count 0) [
+                                        ui_small_spacer
+                                        serverinfo_player_count = (getserver $i 2)
+                                        if (> $serverinfo_player_count 0) [
+                                            ui_font "little" [
+                                                pname = ""
+                                                plist = ""
+                                                pmore = 0
+                                                loop j $serverinfo_player_count [
+                                                    if (|| $pmore (>= (ui_text_width $plist) 1400)) [ pmore = (+ $pmore 1) ] [
+                                                        append pname (format ["%1"] (getserver $i 2 $j))
+                                                        plist = (prettylist $pname)
+                                                    ]
+                                                ]
+                                                ui_button (concat $plist (? $pmore (concat "and^fy" $pmore "^fwmore")))
+                                                //[] [] "" -1 -1 1900
+                                            ]
+                                        ] [ ui_button "^faPlayer info not available" ]
+                                    ] [ ui_button "^faNo players online" ]
+                                ]
+                            ]
+                        ] [
+                            ui_list [
+                                ui_small_spacer
+                                ui_font "default" [ ui_button "^foUnresponsive" [] [] "textures/servers/failed" ]
+                                ui_button " ^faServer is not replying to queries"
+                            ]
                         ]
-                    ]
-                ] [
-                    ui_list [
-                        ui_small_spacer
-                        ui_font "default" [ ui_button "^foUnresponsive" [] [] "textures/servers/failed" ]
-                        ui_button " ^faServer is not replying to queries"
                     ]
                 ]
             ]


### PR DESCRIPTION
I adjusted the serverbrowser style so it fits more with the new map selector:
![Screenshot from 2020-07-05 14-00-24](https://user-images.githubusercontent.com/37220464/86532184-231c1100-bec8-11ea-99fc-77927d36cae5.png)
Also, the serverbrowser window doesn't resize anymore when you search for smth:
![Screenshot from 2020-07-05 14-00-32](https://user-images.githubusercontent.com/37220464/86532192-38913b00-bec8-11ea-87fc-334d6a3b7536.png)
I moved the "Identify as xx" into the bottom info bar and aligned it to the right, as it takes less space like this.
The favourite star is just a placeholder for now, it doesn't do anything. I plan on adding functionality in a separate PR