### PR TITLE
Replace globs in CMake

### DIFF
--- a/src/cmake/build_client.cmake
+++ b/src/cmake/build_client.cmake
@@ -73,14 +73,6 @@ if(BUILD_CLIENT)
             xcode/macutils.mm
             xcode/ConsoleView.m
         )
-
-        # on macOS natively, we don't seem to require that file (any more?)
-        # osxcross however appears to need it
-        if(OSXCROSS_HOST)
-            message(STATUS "osxcross build, building main.m for client")
-            list(APPEND mac_client_sources xcode/main.m)
-        endif()
-
         list(APPEND client_sources ${mac_client_sources})
     elseif(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         find_package(PkgConfig REQUIRED)

--- a/src/cmake/build_client.cmake
+++ b/src/cmake/build_client.cmake
@@ -1,11 +1,65 @@
 if(BUILD_CLIENT)
     # the client depends on almost all the source files
-    file(GLOB client_sources engine/*.cpp game/*.cpp shared/*.cpp)
-
-    # the client does not need genkey.cpp
-    # to avoid warnings about duplicate main()s, it has to be removed from their source lists
-    file(GLOB genkey_cpp_path engine/genkey.cpp)
-    list(REMOVE_ITEM client_sources ${genkey_cpp_path})
+    set(client_sources
+        engine/bih.cpp
+        engine/blend.cpp
+        engine/blob.cpp
+        engine/client.cpp
+        engine/command.cpp
+        engine/console.cpp
+        engine/decal.cpp
+        engine/dynlight.cpp
+        engine/glare.cpp
+        engine/grass.cpp
+        engine/irc.cpp
+        engine/lightmap.cpp
+        engine/main.cpp
+        engine/master.cpp
+        engine/material.cpp
+        engine/menus.cpp
+        engine/normal.cpp
+        engine/octa.cpp
+        engine/octaedit.cpp
+        engine/octarender.cpp
+        engine/physics.cpp
+        engine/pvs.cpp
+        engine/rendergl.cpp
+        engine/rendermodel.cpp
+        engine/renderparticles.cpp
+        engine/rendersky.cpp
+        engine/rendertext.cpp
+        engine/renderva.cpp
+        engine/server.cpp
+        engine/serverbrowser.cpp
+        engine/shader.cpp
+        engine/shadowmap.cpp
+        engine/sound.cpp
+        engine/texture.cpp
+        engine/ui.cpp
+        engine/water.cpp
+        engine/world.cpp
+        engine/worldio.cpp
+        game/ai.cpp
+        game/bomber.cpp
+        game/capture.cpp
+        game/client.cpp
+        game/defend.cpp
+        game/entities.cpp
+        game/game.cpp
+        game/hud.cpp
+        game/physics.cpp
+        game/projs.cpp
+        game/scoreboard.cpp
+        game/server.cpp
+        game/waypoint.cpp
+        game/weapons.cpp
+        shared/crypto.cpp
+        shared/geom.cpp
+        shared/glemu.cpp
+        shared/stream.cpp
+        shared/tools.cpp
+        shared/zip.cpp
+    )
 
     # dependencies are imported globally in src/CMakeLists.txt
     # we can just list them by name here
@@ -14,7 +68,11 @@ if(BUILD_CLIENT)
     # platform specific code
     if(APPLE)
         # build OS X specific Objective-C code
-        file(GLOB mac_client_sources xcode/SDLmain.m xcode/macutils.mm xcode/ConsoleView.m)
+        set(mac_client_sources
+            xcode/SDLMain.m
+            xcode/macutils.mm
+            xcode/ConsoleView.m
+        )
 
         # on macOS natively, we don't seem to require that file (any more?)
         # osxcross however appears to need it
@@ -22,6 +80,7 @@ if(BUILD_CLIENT)
             message(STATUS "osxcross build, building main.m for client")
             list(APPEND mac_client_sources xcode/main.m)
         endif()
+
         list(APPEND client_sources ${mac_client_sources})
     elseif(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         find_package(PkgConfig REQUIRED)

--- a/src/cmake/build_genkey.cmake
+++ b/src/cmake/build_genkey.cmake
@@ -1,6 +1,6 @@
 if(BUILD_GENKEY)
     # genkey is a rather small application
-    file(GLOB genkey_sources
+    set(genkey_sources
         engine/genkey.cpp
         shared/crypto.cpp
     )

--- a/src/cmake/build_server.cmake
+++ b/src/cmake/build_server.cmake
@@ -1,6 +1,6 @@
 if(BUILD_SERVER)
     # the server requires less source files than the client, so we pick them by hand
-    file(GLOB server_sources
+    set(server_sources
         shared/crypto.cpp
         shared/geom.cpp
         shared/stream.cpp
@@ -23,7 +23,7 @@ if(BUILD_SERVER)
         list(APPEND server_deps rt)
     elseif(APPLE)
         # build OS X specific Objective-C code
-        file(GLOB mac_server_sources
+        set(mac_server_sources
             xcode/macutils.mm
         )
         list(APPEND server_sources ${mac_server_sources})

--- a/src/xcode/main.m
+++ b/src/xcode/main.m
@@ -1,6 +1,0 @@
-#import <Cocoa/Cocoa.h>
-
-int main(int argc, char *argv[])
-{
-    return NSApplicationMain(argc,  (const char **) argv);
-}


### PR DESCRIPTION
A source of bugs for a long time, this PR finally replaces the globs with explicit lists of source code files in the CMake scripts. They not only were annoying when adding or renaming code files (one had to re-run CMake manually), they also confused some IDEs we use, apparently.

It turned out that one glob was even source of a bug (or rather, difference) due to a name spelling issue. That was fixed, and `main.m` could finally be removed completely from the source code.

Note that I didn't touch the glob for the win binaries. Their inclusion depends on the binary prefix, and it's easier to glob here. Also, those files will probably never change. And for release builds, our scripts build in a fresh working directory anyway.