### PR TITLE
Do not remove the COMPLETE flag when setting existing aliases.

### DIFF
--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -424,13 +424,21 @@ static inline void setarg(ident &id, tagval &v)
     }
 }
 
+// Write a new value to an existing alias.
 static inline void setalias(ident &id, tagval &v)
 {
+    // Free the previous string if needed.
     if(id.valtype == VAL_STR) delete[] id.val.s;
+
+    // Set the new value.
     id.setval(v);
     cleancode(id);
-    id.flags = (id.flags & (identflags|IDF_WORLD)) | (id.flags & (identflags|IDF_PERSIST)) | identflags;
+
+    // Reset the ident's flags to the global state, except preserving WORLD, PERSIST, and COMPLETE.
+    id.flags = identflags | (id.flags & (IDF_WORLD | IDF_PERSIST | IDF_COMPLETE));
+
 #ifndef STANDALONE
+    // Propagate the change.
     client::editvar(&id, interactive && !(identflags&IDF_WORLD));
 #endif
 }


### PR DESCRIPTION
Currently aliases have their COMPLETE (enable tab-completion in console) flag reset when a new value is written; this is unexpected behavior and inhibits setcomplete functionality.
Specific example: `hideincompleteservers` which is both PERSIST and COMPLETE has its flags set as usual at initial creation, but when config.cfg is executed its COMPLETE flag will be lost.

This PR's primary purpose is to allow aliases that get saved in config.cfg to keep their complete flag. This persist-complete is the only type of situation where this flag reset is an issue in the current codebase, and the only place where this PR makes a difference.