### PR TITLE
Add headers to CMake targets

### DIFF
--- a/src/cmake/build_client.cmake
+++ b/src/cmake/build_client.cmake
@@ -39,6 +39,34 @@ if(BUILD_CLIENT)
         engine/water.cpp
         engine/world.cpp
         engine/worldio.cpp
+        engine/animmodel.h
+        engine/bih.h
+        engine/depthfx.h
+        engine/engine.h
+        engine/explosion.h
+        engine/iqm.h
+        engine/irc.h
+        engine/lensflare.h
+        engine/lightmap.h
+        engine/lightning.h
+        engine/md2.h
+        engine/md3.h
+        engine/md5.h
+        engine/model.h
+        engine/mpr.h
+        engine/obj.h
+        engine/octa.h
+        engine/ragdoll.h
+        engine/rendertarget.h
+        engine/scale.h
+        engine/skelmodel.h
+        engine/smd.h
+        engine/sound.h
+        engine/textedit.h
+        engine/texture.h
+        engine/version.h
+        engine/vertmodel.h
+        engine/world.h
         game/ai.cpp
         game/bomber.cpp
         game/capture.cpp
@@ -53,12 +81,40 @@ if(BUILD_CLIENT)
         game/server.cpp
         game/waypoint.cpp
         game/weapons.cpp
+        game/ai.h
+        game/aiman.h
+        game/auth.h
+        game/bomber.h
+        game/bombermode.h
+        game/capture.h
+        game/capturemode.h
+        game/compass.h
+        game/defend.h
+        game/defendmode.h
+        game/duelmut.h
+        game/game.h
+        game/gamemode.h
+        game/player.h
+        game/playerdef.h
+        game/teamdef.h
+        game/vars.h
+        game/weapdef.h
+        game/weapons.h
         shared/crypto.cpp
         shared/geom.cpp
         shared/glemu.cpp
         shared/stream.cpp
         shared/tools.cpp
         shared/zip.cpp
+        shared/command.h
+        shared/cube.h
+        shared/ents.h
+        shared/geom.h
+        shared/glemu.h
+        shared/glexts.h
+        shared/iengine.h
+        shared/igame.h
+        shared/tools.h
     )
 
     # dependencies are imported globally in src/CMakeLists.txt
@@ -69,8 +125,10 @@ if(BUILD_CLIENT)
     if(APPLE)
         # build OS X specific Objective-C code
         set(mac_client_sources
+            xcode/SDLMain.h
             xcode/SDLMain.m
             xcode/macutils.mm
+            xcode/ConsoleView.h
             xcode/ConsoleView.m
         )
         list(APPEND client_sources ${mac_client_sources})

--- a/src/cmake/build_genkey.cmake
+++ b/src/cmake/build_genkey.cmake
@@ -1,6 +1,20 @@
 if(BUILD_GENKEY)
     # genkey is a rather small application
     set(genkey_sources
+        # list generated using
+        # scripts/trace-headers.py -DSTANDALONE <all .cpp files listed below>
+        engine/genkey.cpp
+        shared/command.h
+        shared/crypto.cpp
+        shared/cube.h
+        shared/ents.h
+        shared/geom.h
+        shared/glemu.h
+        shared/glexts.h
+        shared/iengine.h
+        shared/igame.h
+        shared/tools.h
+
         engine/genkey.cpp
         shared/crypto.cpp
     )

--- a/src/cmake/build_server.cmake
+++ b/src/cmake/build_server.cmake
@@ -1,6 +1,37 @@
 if(BUILD_SERVER)
     # the server requires less source files than the client, so we pick them by hand
     set(server_sources
+        # list generated using
+        # scripts/trace-headers.py -DSTANDALONE -DGAMESERVER <all .cpp files listed below>
+        engine/engine.h
+        engine/irc.h
+        engine/sound.h
+        engine/version.h
+        game/aiman.h
+        game/auth.h
+        game/bomber.h
+        game/bombermode.h
+        game/capture.h
+        game/capturemode.h
+        game/defend.h
+        game/defendmode.h
+        game/duelmut.h
+        game/game.h
+        game/gamemode.h
+        game/player.h
+        game/playerdef.h
+        game/teamdef.h
+        game/vars.h
+        game/weapdef.h
+        game/weapons.h
+        shared/command.h
+        shared/cube.h
+        shared/ents.h
+        shared/geom.h
+        shared/iengine.h
+        shared/igame.h
+        shared/tools.h
+
         shared/crypto.cpp
         shared/geom.cpp
         shared/stream.cpp

--- a/src/scripts/trace-headers.py
+++ b/src/scripts/trace-headers.py
@@ -1,0 +1,118 @@
+#! /usr/bin/python3
+
+import os
+import shlex
+import subprocess
+import sys
+
+from typing import List, Iterable, Set
+
+
+def get_deps_for_single_file(filename: str, extra_flags: List[str]) -> Iterable[str]:
+    command = ["g++", "-Igame", "-Iengine", "-Ishared", "-I/usr/include/SDL2"]
+
+    # append additional compiler flags
+    command += extra_flags
+
+    # generate make-style dependency lists
+    command.append("-M")
+
+    command.append(filename)
+
+    print(" ".join([shlex.quote(i) for i in command]), file=sys.stderr)
+
+    out = subprocess.check_output(command).decode()
+
+    if os.environ.get("DEBUG", None):
+        print(out, file=sys.stderr)
+
+    for line in out.splitlines():
+        parts = line.split(" ")
+
+        # handles indentation and other annoying whitespace
+        try:
+            parts.remove("")
+        except ValueError:
+            pass
+
+        # we don't need the escaping at the line ends
+        try:
+            parts.remove("\\")
+        except ValueError:
+            pass
+
+        for part in parts:
+            # ignore own object file
+            if part.endswith(".o:"):
+                continue
+
+            # we don't need code dependencies
+            if part.endswith(".cpp"):
+                continue
+
+            # same goes for system-wide includes
+            if part.startswith("/usr"):
+                continue
+
+            yield part
+
+
+def recursive_trace(filename: str, extra_flags: List[str]):
+    # note: since files can include each other in this weird codebase, it's important to terminate once no more new
+    # includes are found
+
+    def get_deps(f: str, deps: Set[str] = None):
+        if deps is None:
+            deps = set()
+
+        new_deps = set(get_deps_for_single_file(f, extra_flags))
+
+        # remove all existing includes as well as the own file (unless it's source code) from the list before adding
+        # them to the set to be able to make sure the for loop only runs on new files
+        if not f.endswith(".cpp"):
+            deps.add(f)
+
+        for dep in deps:
+            try:
+                new_deps.remove(dep)
+            except KeyError:
+                pass
+
+        deps = deps.union(new_deps)
+
+        # if there's any more includes, we can recurse down, otherwise this function will terminate
+        for dep in new_deps:
+            deps = deps.union(get_deps(dep))
+
+        return deps
+
+    return get_deps(filename)
+
+
+def main():
+    deps = set()
+
+    files = []
+    flags = []
+
+    for i in sys.argv[1:]:
+        if i.startswith("-"):
+            flags.append(i)
+        else:
+            files.append(i)
+
+    if not files:
+        print("Usage:", sys.argv[0], "file [file...] [-mycompilerflag]", file=sys.stderr)
+        print("Note: this tool is supposed to run from Blue Nebula src/ directory")
+        return 1
+
+    for file in files:
+        deps = deps.union(recursive_trace(file, flags))
+
+    deps = list(deps)
+    deps.sort()
+    print("\n".join(deps))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This fixes the code inspection in some IDEs, and is generally good style, as CMake can then react to changes in these files better.

Follow-up for #105, where I forgot to add these, too (I just used the globs in CMake to determine the list of files). I traced the header files required for server and genkey by hand.

The PR further adds a script that can be used to trace all includes recursively from code files. It uses `g++` internally for the heavy lifting. This will be handy if we ever have to update the header lists. It already helped add a few headers I missed when traving the headers by hand. 