### PR TITLE
Add hide/mute chat functionality

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -270,11 +270,14 @@ options_console = [
         ]
     ]
 
-    ui_font "little" [ ui_text "^faDefault: 32" ]
+    ui_font "little" [ ui_text "^faDefault: 32" ]; ui_strut 0.5
 
-    ui_strut 0.5
+    ui_checkbox "Play sound when mentioned in chat" playmentionedsound; ui_strut 0.5
 
-    ui_checkbox "Play sound when mentioned in chat" playmentionedsound
+    ui_list [
+        ui_checkbox "Hide Chat" hidechat; ui_strut 0.5
+        ui_checkbox "Mute Chat" mutechat
+    ]
 ]
 
 // GENERAL OPTIONS

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -19,6 +19,7 @@ namespace client
     VAR(IDF_PERSIST, showservervariables, 0, 0, 1); // determines if variables set by the server are printed to the console
     VAR(IDF_PERSIST, showmapvotes, 0, 1, 3); // shows map votes, 1 = only mid-game (not intermision), 2 = at all times, 3 = verbose
     VAR(IDF_PERSIST, playmentionedsound, 0, 0, 1);
+    VAR(IDF_PERSIST, mutechat, 0, 0, 2); // mute chat sounds, 1 = mute in-game, 2 mute in-game and in spectator
 
     VAR(IDF_PERSIST, checkpointannounce, 0, 5, 7); // 0 = never, &1 = active players, &2 = all players, &4 = all players in gauntlet
     VAR(IDF_PERSIST, checkpointannouncefilter, 0, CP_ALL, CP_ALL); // which checkpoint types to announce for
@@ -1168,13 +1169,19 @@ namespace client
         {
             conoutft(CON_CHAT, "%s", line);
 
-            if (playmentionedsound && (strstr(text, game::player1.name) != NULL))
+            // only play chat sounds when
+            // (mutechat is 1 and player is not alive OR mutechat is 0)
+            if ((mutechat == 1 && game::player1.state != CS_ALIVE)
+                  || mutechat == 0 )
             {
-                playsound(S_MENTIONED, f->o, f, 0, -1, -1, -1, &f->cschan);
-            }
-            else if (snd >= 0 && !issound(f->cschan))
-            {
-                playsound(snd, f->o, f, snd != S_CHAT ? 0 : SND_DIRECT, -1, -1, -1, &f->cschan);
+                if (playmentionedsound && (strstr(text, game::player1.name) != NULL))
+                {
+                    playsound(S_MENTIONED, f->o, f, 0, -1, -1, -1, &f->cschan);
+                }
+                else if (snd >= 0 && !issound(f->cschan))
+                {
+                    playsound(snd, f->o, f, snd != S_CHAT ? 0 : SND_DIRECT, -1, -1, -1, &f->cschan);
+                }
             }
         }
         ai::scanchat(f, t, flags, text);

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -26,6 +26,8 @@ namespace hud
     FVAR(IDF_PERSIST, hudblend, 0, 1, 1);
     VAR(IDF_PERSIST, hudminimal, 0, 0, 1);
 
+    VAR(IDF_PERSIST, hidechat, 0, 0, 2); // toggle visibility of chat, 1 = hide in-game, 2 hide in-game and in spectator
+
     VAR(IDF_PERSIST, showdemoplayback, 0, 1, 1);
     FVAR(IDF_PERSIST, edgesize, 0, 0.005f, 1000);
 
@@ -1768,8 +1770,22 @@ namespace hud
         bool full = fullconsole || commandmillis > 0;
         int tz = 0;
         pushfont("console");
+
         if(type >= 2)
         {
+            // draw the chat
+
+            // (don't draw the chat if hidechat is 1 and the player is alive
+            // OR if hidechat is 2)
+            // AND full is false, so the chat is always shown when full is true
+            if (   ((hidechat == 1 && game::player1.state == CS_ALIVE)
+                   || (hidechat == 2))
+                && (!full) )
+            {
+                popfont();
+                return;
+            }
+
             int numl = chatconsize, numo = chatconsize+chatconoverflow;
             loopvj(conlines) if(conlines[j].type >= CON_CHAT)
             {
@@ -1813,6 +1829,7 @@ namespace hud
         }
         else
         {
+            // draw the console
             if((showconsole && showhud) || commandmillis > 0)
             {
                 int numl = consize, numo = consize+conoverflow;


### PR DESCRIPTION
This PR adds two checkboxes to the console options which toggle `mutechat` and `hidechat`
![Screenshot from 2020-07-11 11-05-44](https://user-images.githubusercontent.com/37220464/87220724-b04ae400-c366-11ea-8199-76c8cbdacf57.png)

If `hidechat`/`mutechat` is set to 1, it only hides/mutes the chat while the player is alive,
if it is set to 2 it always hides/mutes the chat, except for hide which can be "overriden" by opening the chat textfield