### PR TITLE
Remove main menu color codes from C++

### DIFF
--- a/config/menus/main.cfg
+++ b/config/menus/main.cfg
@@ -14,23 +14,23 @@ new_ui main [
     ] [
         ui_list [ ui_strut 30 ]
         ui_list [ ui_list [ ui_font "emphasis" [
-            
-            ui_font "huge" [ ui_button "^fh PLAY ONLINE" "showservers" "" "textures/icons/fontawesome/play_online.png" 0xFFFFFF 0x32b842 ]
+
+            ui_font "huge" [ ui_button "^f[0x32B842] PLAY ONLINE" "showservers" "" "textures/icons/fontawesome/play_online.png" 0xFFFFFF 0x32b842 ]
 
             ui_small_spacer
             ui_small_spacer
 
             if (isconnected) [
                 ui_button " Vote Map/Mode" "show_ui maps 1" "" "textures/icons/fontawesome/vote_map__mode.png"
-                
+
                 ui_small_spacer
-                
+
                 // Show Votes button
                 if (> (getvote) 0) [
                     ui_button "^fy Show Votes" "show_ui maps 2" "" "textures/icons/fontawesome/show_votes.png" // "Show Votes" button
                 ]
             ] [
-                ui_button "^fi Offline Practice" "show_ui maps 1" "" "textures/icons/fontawesome/offline_practice.png" 0xFFFFFF 0x196db6
+                ui_button "^f[0x196DB6] Offline Practice" "show_ui maps 1" "" "textures/icons/fontawesome/offline_practice.png" 0xFFFFFF 0x196db6
             ]
 
             ui_big_spacer
@@ -50,8 +50,8 @@ new_ui main [
                 ui_button " Disconnect" "savewarnchk disconnect" "" "textures/icons/fontawesome/disconnect.png" // "Disconnect" button
                 ui_small_spacer
             ]
-            ui_button "^fj Quit Game" "savewarnchk quit" "" "textures/icons/fontawesome/quit.png" 0xFFFFFF 0xff321b// "Quit" button
-        ] ] ] 
+            ui_button "^f[0xFF321B] Quit Game" "savewarnchk quit" "" "textures/icons/fontawesome/quit.png" 0xFFFFFF 0xff321b// "Quit" button
+        ] ] ]
     ]
     cases $guirolloveraction "showservers" [
         ui_tooltip "display the server browser for online matches"

--- a/src/engine/rendertext.cpp
+++ b/src/engine/rendertext.cpp
@@ -249,9 +249,6 @@ static void text_color(char c, bvec4 *stack, int size, int &sp, bvec4 &color, in
         case 'w': case '7': stack[sp] = color = TVECX(255, 255, 255, alpha); break; // white
         case 'k': case '8': stack[sp] = color = TVECX(0,     0,   0, alpha); break; // black
         case 'c': case '9': stack[sp] = color = TVECX(64,  255, 255, alpha); break; // cyan
-        case 'h': stack[sp] = color = TVECX( 50, 184,  66, alpha); break; // play online
-        case 'i': stack[sp] = color = TVECX( 25, 109, 182, alpha); break; // offline practice
-        case 'j': stack[sp] = color = TVECX(255,  50,  27, alpha); break; // quit game
         case 'v': stack[sp] = color = TVECX(192,  96, 255, alpha); break; // violet
         case 'p': stack[sp] = color = TVECX(224,  64, 224, alpha); break; // purple
         case 'n': stack[sp] = color = TVECX(164,  72,  56, alpha); break; // brown


### PR DESCRIPTION
Play online, offline practice, and quit had special format code characters in text_color(), which are replaced by hex color format codes.

C++ shouldn't have such a close connection to arbitrary CubeScript.