### PR TITLE
Default indicatorminattack to 400.

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -247,6 +247,8 @@ setdesc "muzzleflare" "0 = off, 1 = only other players, 2 = only thirdperson, 3 
 setdesc "underlaydisplay" "0 = only firstperson and alive, 1 = only when alive, 2 = always" "value"
 setdesc "overlaydisplay" "0 = only firstperson and alive, 1 = only when alive, 2 = always" "value"
 setdesc "showdamage" "1 shows just damage texture, 2 blends as well" "value"
+setdesc "showindicator" "display an indicator of weapon delays around the crosshair;^n0 = off, 1 = display cooking delays, 2 = also display reloading for weapons that reload the whole clip, 3 = also display reloading for other weapons, 4 = also display attacking delays for weapons with attack delays of at least indicatorminattack." "value"
+setdesc "indicatorminattack" "determines the minimum attack delay for a weapon to display its attack delay in the indicator around the crosshair" "value"
 setdesc "showcrosshair" "0 = off, 1 = on, 2 = blend depending on current accuracy level" "value"
 setdesc "crosshairweapons" "0 = off, 1 = crosshair-specific weapons, 2 = also appy colour" "value"
 setdesc "cursorstyle" "0 = top left tracking, 1 = center" "value"

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -216,7 +216,7 @@ namespace hud
     VAR(IDF_PERSIST, showindicator, 0, 4, 4);
     FVAR(IDF_PERSIST, indicatorsize, 0, 0.03f, 1000);
     FVAR(IDF_PERSIST, indicatorblend, 0, 0.5f, 1);
-    VAR(IDF_PERSIST, indicatorminattack, 0, 1000, VAR_MAX);
+    VAR(IDF_PERSIST, indicatorminattack, 0, 400, VAR_MAX);
     TVAR(IDF_PERSIST|IDF_GAMEPRELOAD, indicatortex, "<grey>textures/hud/indicator", 3);
 
     VAR(IDF_PERSIST, showcrosshair, 0, 2, 2); // 0 = off, 1 = on, 2 = blend depending on current accuracy level
@@ -2199,11 +2199,11 @@ namespace hud
             }
             colour[1] = vec::hexcolor(game::getcolour(d, game::playerovertone, game::playerovertonelevel));
             const char *tex = isdominated ? dominatedtex : (killer || self ? arrowtex : playerbliptex);
-            if (d->conopen) 
+            if (d->conopen)
             {
-                tex = chattex; 
+                tex = chattex;
             }
-            
+
             float fade = (force || killer || self || dominated ? 1.f : clamp(1.f-(dist/float(radarrange())), isdominated ? 0.25f : 0.f, 1.f))*blend, size = killer || self ? 1.5f : (isdominated ? 1.25f : 1.f);
             if(!self && (d->state == CS_DEAD || d->state == CS_WAITING))
             {


### PR DESCRIPTION
This default is better to determining timing for many slow-ish weapons.

Document showindicator and indicatorminattack.
Closes #126