### PR TITLE
Fix bug: Server list not showing after guidelines

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -554,4 +554,4 @@ new_ui guidelines [
     ]
     ui_status "You must read and agree to these guidelines before playing online"
 ] [ if $connectguidelines [clear_ui 1] ]
-showservers = [ guidelinesaction "show_ui servers"; show_ui (? $connectguidelines Servers guidelines) ]
+showservers = [ guidelinesaction "show_ui Servers"; show_ui (? $connectguidelines Servers guidelines) ]


### PR DESCRIPTION
This is fixed by changing "show_ui servers" to "show_ui Servers" because
the name of the Servers ui has been changed in a previous commit but in
this place the old name was still used.

Fixes #146