### PR TITLE
glemu deadcode and macro purge

### DIFF
--- a/src/shared/glemu.h
+++ b/src/shared/glemu.h
@@ -1,18 +1,19 @@
 #ifndef GLEMU_H
 #define GLEMU_H
+
 namespace gle
 {
     enum
     {
-        ATTRIB_VERTEX       = 0,
-        ATTRIB_COLOR        = 1,
-        ATTRIB_TEXCOORD0    = 2,
-        ATTRIB_TEXCOORD1    = 3,
-        ATTRIB_NORMAL       = 4,
-        ATTRIB_TANGENT      = 5,
-        ATTRIB_BONEWEIGHT   = 6,
-        ATTRIB_BONEINDEX    = 7,
-        MAXATTRIBS          = 8
+        ATTRIB_VERTEX = 0,
+        ATTRIB_COLOR = 1,
+        ATTRIB_TEXCOORD0 = 2,
+        ATTRIB_TEXCOORD1 = 3,
+        ATTRIB_NORMAL = 4,
+        ATTRIB_TANGENT = 5,
+        ATTRIB_BONEWEIGHT = 6,
+        ATTRIB_BONEINDEX = 7,
+        MAXATTRIBS = 8
     };
 
     extern const char * const attribnames[MAXATTRIBS];
@@ -25,66 +26,53 @@ namespace gle
     extern void begin(GLenum mode);
     extern void begin(GLenum mode, int numverts);
     extern void multidraw();
-    extern void defattribs(const char *fmt);
     extern void defattrib(int type, int size, int format);
 
-    #define GLE_DEFATTRIB(name, type, defaultsize, defaultformat) \
-        static inline void def##name(int size = defaultsize, int format = defaultformat) { defattrib(type, size, format); }
+    static inline void defvertex(int size = 3, int format = GL_FLOAT) { defattrib(ATTRIB_VERTEX, size, format); }
+    static inline void defcolor(int size = 3, int format = GL_FLOAT) { defattrib(ATTRIB_COLOR, size, format); }
+    static inline void deftexcoord0(int size = 2, int format = GL_FLOAT) { defattrib(ATTRIB_TEXCOORD0, size, format); }
+    static inline void defnormal(int size = 3, int format = GL_FLOAT) { defattrib(ATTRIB_NORMAL, size, format); }
+    static inline void deftangent(int size = 4, int format = GL_FLOAT) { defattrib(ATTRIB_TANGENT, size, format); }
 
-    GLE_DEFATTRIB(vertex, ATTRIB_VERTEX, 3, GL_FLOAT)
-    GLE_DEFATTRIB(color, ATTRIB_COLOR, 3, GL_FLOAT)
-    GLE_DEFATTRIB(texcoord0, ATTRIB_TEXCOORD0, 2, GL_FLOAT)
-    GLE_DEFATTRIB(texcoord1, ATTRIB_TEXCOORD1, 2, GL_FLOAT)
-    GLE_DEFATTRIB(normal, ATTRIB_NORMAL, 3, GL_FLOAT)
-    GLE_DEFATTRIB(tangent, ATTRIB_TANGENT, 4, GL_FLOAT)
-    GLE_DEFATTRIB(boneweight, ATTRIB_BONEWEIGHT, 4, GL_UNSIGNED_BYTE)
-    GLE_DEFATTRIB(boneindex, ATTRIB_BONEINDEX, 4, GL_UNSIGNED_BYTE)
-
-    #define GLE_INITATTRIB(name, index, suffix, type) \
-        static inline void name##suffix(type x) { glVertexAttrib1##suffix##_(index, x); } \
-        static inline void name##suffix(type x, type y) { glVertexAttrib2##suffix##_(index, x, y); } \
-        static inline void name##suffix(type x, type y, type z) { glVertexAttrib3##suffix##_(index, x, y, z); } \
-        static inline void name##suffix(type x, type y, type z, type w) { glVertexAttrib4##suffix##_(index, x, y, z, w); }
-    #define GLE_INITATTRIBF(name, index) \
-        GLE_INITATTRIB(name, index, f, float) \
-        static inline void name(const vec &v) { glVertexAttrib3fv_(index, v.v); } \
-        static inline void name(const vec &v, float w) { glVertexAttrib4f_(index, v.x, v.y, v.z, w); } \
-        static inline void name(const vec2 &v) { glVertexAttrib2fv_(index, v.v); } \
-        static inline void name(const vec4 &v) { glVertexAttrib4fv_(index, v.v); }
-    #define GLE_INITATTRIBN(name, index, suffix, type, defaultw) \
-        static inline void name##suffix(type x, type y, type z, type w = defaultw) { glVertexAttrib4N##suffix##_(index, x, y, z, w); }
-
-    GLE_INITATTRIBF(vertex, ATTRIB_VERTEX)
-    GLE_INITATTRIBF(color, ATTRIB_COLOR)
-    GLE_INITATTRIBN(color, ATTRIB_COLOR, ub, uchar, 255)
+    static inline void colorf(float x, float y, float z) { glVertexAttrib3f_(ATTRIB_COLOR, x, y, z); }
+    static inline void colorf(float x, float y, float z, float w) { glVertexAttrib4f_(ATTRIB_COLOR, x, y, z, w); }
+    static inline void color(const vec &v) { glVertexAttrib3fv_(ATTRIB_COLOR, v.v); }
+    static inline void color(const vec &v, float w) { glVertexAttrib4f_(ATTRIB_COLOR, v.x, v.y, v.z, w); }
+    static inline void colorub(uchar x, uchar y, uchar z, uchar w = 255) { glVertexAttrib4Nub_(ATTRIB_COLOR, x, y, z, w); }
     static inline void color(const bvec &v, uchar alpha = 255) { glVertexAttrib4Nub_(ATTRIB_COLOR, v.x, v.y, v.z, alpha); }
     static inline void color(const bvec4 &v) { glVertexAttrib4Nubv_(ATTRIB_COLOR, v.v); }
-    GLE_INITATTRIBF(texcoord0, ATTRIB_TEXCOORD0)
-    GLE_INITATTRIBF(texcoord1, ATTRIB_TEXCOORD1)
-    static inline void normal(float x, float y, float z) { glVertexAttrib4f_(ATTRIB_NORMAL, x, y, z, 0.0f); }
-    static inline void normal(const vec &v) { glVertexAttrib4f_(ATTRIB_NORMAL, v.x, v.y, v.z, 0.0f); }
-    static inline void tangent(float x, float y, float z, float w = 1.0f) { glVertexAttrib4f_(ATTRIB_TANGENT, x, y, z, w); }
-    static inline void tangent(const vec &v, float w = 1.0f) { glVertexAttrib4f_(ATTRIB_TANGENT, v.x, v.y, v.z, w); }
-    static inline void tangent(const vec4 &v) { glVertexAttrib4fv_(ATTRIB_TANGENT, v.v); }
 
-    #define GLE_ATTRIBPOINTER(name, index, defaultnormalized, defaultsize, defaulttype, prepare) \
-        static inline void enable##name() { prepare; glEnableVertexAttribArray_(index); } \
-        static inline void disable##name() { glDisableVertexAttribArray_(index); } \
-        static inline void name##pointer(int stride, const void *data, GLenum type = defaulttype, int size = defaultsize, GLenum normalized = defaultnormalized) { \
-            prepare; \
-            glVertexAttribPointer_(index, size, type, normalized, stride, data); \
-        }
+    static inline void enablevertex() { disable(); glEnableVertexAttribArray_(ATTRIB_VERTEX); }
+    static inline void disablevertex() { glDisableVertexAttribArray_(ATTRIB_VERTEX); }
+    static inline void vertexpointer(int stride, const void *data, GLenum type = GL_FLOAT, int size = 3, GLenum normalized = GL_FALSE) { disable(); glVertexAttribPointer_(ATTRIB_VERTEX, size, type, normalized, stride, data); }
 
-    static inline void enableattrib(int index) { disable(); glEnableVertexAttribArray_(index); }
-    static inline void disableattrib(int index) { glDisableVertexAttribArray_(index); }
-    GLE_ATTRIBPOINTER(vertex, ATTRIB_VERTEX, GL_FALSE, 3, GL_FLOAT, disable())
-    GLE_ATTRIBPOINTER(color, ATTRIB_COLOR, GL_TRUE, 4, GL_UNSIGNED_BYTE, )
-    GLE_ATTRIBPOINTER(texcoord0, ATTRIB_TEXCOORD0, GL_FALSE, 2, GL_FLOAT, )
-    GLE_ATTRIBPOINTER(texcoord1, ATTRIB_TEXCOORD1, GL_FALSE, 2, GL_FLOAT, )
-    GLE_ATTRIBPOINTER(normal, ATTRIB_NORMAL, GL_TRUE, 3, GL_FLOAT, )
-    GLE_ATTRIBPOINTER(tangent, ATTRIB_TANGENT, GL_TRUE, 4, GL_FLOAT, )
-    GLE_ATTRIBPOINTER(boneweight, ATTRIB_BONEWEIGHT, GL_TRUE, 4, GL_UNSIGNED_BYTE, )
-    GLE_ATTRIBPOINTER(boneindex, ATTRIB_BONEINDEX, GL_FALSE, 4, GL_UNSIGNED_BYTE, )
+    static inline void enablecolor() { ; glEnableVertexAttribArray_(ATTRIB_COLOR); }
+    static inline void disablecolor() { glDisableVertexAttribArray_(ATTRIB_COLOR); }
+    static inline void colorpointer(int stride, const void *data, GLenum type = GL_UNSIGNED_BYTE, int size = 4, GLenum normalized = GL_TRUE) { ; glVertexAttribPointer_(ATTRIB_COLOR, size, type, normalized, stride, data); }
+
+    static inline void enabletexcoord0() { ; glEnableVertexAttribArray_(ATTRIB_TEXCOORD0); }
+    static inline void disabletexcoord0() { glDisableVertexAttribArray_(ATTRIB_TEXCOORD0); }
+    static inline void texcoord0pointer(int stride, const void *data, GLenum type = GL_FLOAT, int size = 2, GLenum normalized = GL_FALSE) { ; glVertexAttribPointer_(ATTRIB_TEXCOORD0, size, type, normalized, stride, data); }
+
+    static inline void enabletexcoord1() { ; glEnableVertexAttribArray_(ATTRIB_TEXCOORD1); }
+    static inline void disabletexcoord1() { glDisableVertexAttribArray_(ATTRIB_TEXCOORD1); }
+    static inline void texcoord1pointer(int stride, const void *data, GLenum type = GL_FLOAT, int size = 2, GLenum normalized = GL_FALSE) { ; glVertexAttribPointer_(ATTRIB_TEXCOORD1, size, type, normalized, stride, data); }
+
+    static inline void enablenormal() { ; glEnableVertexAttribArray_(ATTRIB_NORMAL); }
+    static inline void disablenormal() { glDisableVertexAttribArray_(ATTRIB_NORMAL); }
+    static inline void normalpointer(int stride, const void *data, GLenum type = GL_FLOAT, int size = 3, GLenum normalized = GL_TRUE) { ; glVertexAttribPointer_(ATTRIB_NORMAL, size, type, normalized, stride, data); }
+
+    static inline void enabletangent() { ; glEnableVertexAttribArray_(ATTRIB_TANGENT); }
+    static inline void disabletangent() { glDisableVertexAttribArray_(ATTRIB_TANGENT); }
+    static inline void tangentpointer(int stride, const void *data, GLenum type = GL_FLOAT, int size = 4, GLenum normalized = GL_TRUE) { ; glVertexAttribPointer_(ATTRIB_TANGENT, size, type, normalized, stride, data); }
+
+    static inline void enableboneweight() { ; glEnableVertexAttribArray_(ATTRIB_BONEWEIGHT); }
+    static inline void disableboneweight() { glDisableVertexAttribArray_(ATTRIB_BONEWEIGHT); }
+    static inline void boneweightpointer(int stride, const void *data, GLenum type = GL_UNSIGNED_BYTE, int size = 4, GLenum normalized = GL_TRUE) { ; glVertexAttribPointer_(ATTRIB_BONEWEIGHT, size, type, normalized, stride, data); }
+
+    static inline void enableboneindex() { ; glEnableVertexAttribArray_(ATTRIB_BONEINDEX); }
+    static inline void disableboneindex() { glDisableVertexAttribArray_(ATTRIB_BONEINDEX); }
+    static inline void boneindexpointer(int stride, const void *data, GLenum type = GL_UNSIGNED_BYTE, int size = 4, GLenum normalized = GL_FALSE) { ; glVertexAttribPointer_(ATTRIB_BONEINDEX, size, type, normalized, stride, data); }
 
     static inline void bindebo(GLuint ebo) { disable(); glBindBuffer_(GL_ELEMENT_ARRAY_BUFFER, ebo); }
     static inline void clearebo() { glBindBuffer_(GL_ELEMENT_ARRAY_BUFFER, 0); }
@@ -137,38 +125,23 @@ namespace gle
         }
     }
 
-    template<size_t N, class T>
-    static inline void attribv(const T *v)
-    {
-        attribbuf.put((const uchar *)v, N*sizeof(T));
-    }
+    static inline void attribf(float x, float y) { attrib<float>(x, y); }
+    static inline void attribf(float x, float y, float z) { attrib<float>(x, y, z); }
+    static inline void attribf(float x, float y, float z, float w) { attrib<float>(x, y, z, w); }
+    static inline void attribs(short x, short y) { attrib<short>(x, y); }
+    static inline void attribs(short x, short y, short z) { attrib<short>(x, y, z); }
+    static inline void attribs(short x, short y, short z, short w) { attrib<short>(x, y, z, w); }
+    static inline void attribus(ushort x, ushort y) { attrib<ushort>(x, y); }
+    static inline void attribus(ushort x, ushort y, ushort z) { attrib<ushort>(x, y, z); }
+    static inline void attribus(ushort x, ushort y, ushort z, ushort w) { attrib<ushort>(x, y, z, w); }
+    static inline void attribi(int x, int y) { attrib<int>(x, y); }
+    static inline void attribi(int x, int y, int z) { attrib<int>(x, y, z); }
+    static inline void attribi(int x, int y, int z, int w) { attrib<int>(x, y, z, w); }
+    static inline void attribui(uint x, uint y) { attrib<uint>(x, y); }
+    static inline void attribui(uint x, uint y, uint z) { attrib<uint>(x, y, z); }
+    static inline void attribui(uint x, uint y, uint z, uint w) { attrib<uint>(x, y, z, w); }
 
-    #define GLE_ATTRIB(suffix, type) \
-        static inline void attrib##suffix(type x) { attrib<type>(x); } \
-        static inline void attrib##suffix(type x, type y) { attrib<type>(x, y); } \
-        static inline void attrib##suffix(type x, type y, type z) { attrib<type>(x, y, z); } \
-        static inline void attrib##suffix(type x, type y, type z, type w) { attrib<type>(x, y, z, w); }
-
-    GLE_ATTRIB(f, float)
-    GLE_ATTRIB(d, double)
-    GLE_ATTRIB(b, char)
-    GLE_ATTRIB(ub, uchar)
-    GLE_ATTRIB(s, short)
-    GLE_ATTRIB(us, ushort)
-    GLE_ATTRIB(i, int)
-    GLE_ATTRIB(ui, uint)
-
-    static inline void attrib(const vec &v) { attribf(v.x, v.y, v.z); }
     static inline void attrib(const vec &v, float w) { attribf(v.x, v.y, v.z, w); }
-    static inline void attrib(const vec2 &v) { attribf(v.x, v.y); }
-    static inline void attrib(const vec4 &v) { attribf(v.x, v.y, v.z, v.w); }
-    static inline void attrib(const ivec &v) { attribi(v.x, v.y, v.z); }
-    static inline void attrib(const ivec &v, int w) { attribi(v.x, v.y, v.z, w); }
-    static inline void attrib(const ivec2 &v) { attribi(v.x, v.y); }
-    static inline void attrib(const ivec4 &v) { attribi(v.x, v.y, v.z, v.w); }
-    static inline void attrib(const bvec &b) { attribub(b.x, b.y, b.z); }
-    static inline void attrib(const bvec &b, uchar w) { attribub(b.x, b.y, b.z, w); }
-    static inline void attrib(const bvec4 &b) { attribub(b.x, b.y, b.z, b.w); }
 
     extern int end();
 


### PR DESCRIPTION
Each line was removed, one by one, check that the compilation passed.
On Debian 10, with clang++ and some custum setup, all passes. CI will
check that all damn systems builds. It's the only thing it's setup for,
after all.
I will *not* apply ANY codestyle or doc patch on this, because it's just
a damn cleanup, not real changes.
To redo:
* 1: apply `cpp` on your target
* 2: n = 1
* 3: until EOF
* 4: remove line 1
* 5: build
* 6: if build failed, cancel 3
* 7: n++
* 8: goto 3