### PR TITLE
Use std::swap without "using" keyword

### DIFF
--- a/src/engine/bih.cpp
+++ b/src/engine/bih.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include <vector>
 #include "engine.h"
 
@@ -205,7 +202,7 @@ void BIH::build(mesh &m, ushort *indices, int numindices, const ivec &vmin, cons
             else
             {
                 --right;
-                swap(indices[left], indices[right]);
+                std::swap(indices[left], indices[right]);
                 splitright = min(splitright, amin);
                 rightmin.min(trimin);
                 rightmax.max(trimax);

--- a/src/engine/blend.cpp
+++ b/src/engine/blend.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include <vector>
 #include "engine.h"
 
@@ -520,7 +517,7 @@ struct BlendBrush
             }
             dst += stridey;
         }
-        if(swapxy) swap(w, h);
+        if(swapxy) std::swap(w, h);
         delete[] data;
         data = rdata;
         if(tex) gentex();

--- a/src/engine/blob.cpp
+++ b/src/engine/blob.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 extern int intel_mapbufferrange_bug;

--- a/src/engine/client.cpp
+++ b/src/engine/client.cpp
@@ -1,7 +1,4 @@
 // client.cpp, mostly network related client game code
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 ENetHost *clienthost = NULL;

--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -2,9 +2,7 @@
 // is largely backwards compatible with the quake console language.
 
 #include <vector>
-#include <algorithm>
 #include <string>
-using std::swap;
 #include "engine.h"
 
 bool interactive = false;

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -1,7 +1,5 @@
 // console.cpp: the console buffer, its display, and command line control
-#include <algorithm>
 #include <string>
-using std::swap;
 
 #include "engine.h"
 #include "game.h"

--- a/src/engine/decal.cpp
+++ b/src/engine/decal.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 struct decalvert

--- a/src/engine/dynlight.cpp
+++ b/src/engine/dynlight.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 VAR(IDF_PERSIST, maxdynlights, 0, min(3, MAXDYNLIGHTS), MAXDYNLIGHTS);

--- a/src/engine/genkey.cpp
+++ b/src/engine/genkey.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/engine/glare.cpp
+++ b/src/engine/glare.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 #include "rendertarget.h"
 

--- a/src/engine/grass.cpp
+++ b/src/engine/grass.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 VAR(IDF_PERSIST, grass, 0, 0, 1);

--- a/src/engine/irc.cpp
+++ b/src/engine/irc.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 VAR(0, ircfilter, 0, 2, 2);

--- a/src/engine/lightmap.cpp
+++ b/src/engine/lightmap.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 #define MAXLIGHTMAPTASKS 4096
@@ -695,7 +692,7 @@ static inline void generatealpha(lightmapworker *w, float tolerance, const vec &
         float k = 8.0f/w->vslot->scale,
               s = (pos[sdim[dim]] * k - w->vslot->offset.x) / w->slot->layermaskscale,
               t = (pos[tdim[dim]] * (dim <= 1 ? -k : k) - w->vslot->offset.y) / w->slot->layermaskscale;
-        if((w->rotate&5)==1) swap(s, t);
+        if((w->rotate&5)==1) std::swap(s, t);
         if(w->rotate>=2 && w->rotate<=4) s = -s;
         if((w->rotate>=1 && w->rotate<=2) || w->rotate==5) t = -t;
         const ImageData &mask = *w->slot->layermask;
@@ -863,7 +860,7 @@ static int finishlightmap(lightmapworker *w)
     if((hasskylight() || sunlights.length()) && blurskylight && (w->w>1 || w->h>1))
     {
         blurtexture(blurskylight, w->bpp, w->w, w->h, w->blur, w->ambient);
-        swap(w->blur, w->ambient);
+        std::swap(w->blur, w->ambient);
     }
     vec *sample = w->colordata;
     int aasample = min(1 << lmaa, 4), stride = aasample*(w->w+1);
@@ -2300,7 +2297,7 @@ static void rotatenormals(LightMap &lmlv, int x, int y, int w, int h, int rotate
         {
             if(flipx) lv[0] = 255 - lv[0];
             if(flipy) lv[1] = 255 - lv[1];
-            if(swapxy) swap(lv[0], lv[1]);
+            if(swapxy) std::swap(lv[0], lv[1]);
             lv += 3;
         }
         lv += stride;

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1,7 +1,4 @@
 // main.cpp: initialisation & main loop
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 #include <signal.h>
 

--- a/src/engine/master.cpp
+++ b/src/engine/master.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #ifdef WIN32
 #define FD_SETSIZE 4096
 #else

--- a/src/engine/material.cpp
+++ b/src/engine/material.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 struct QuadNode
@@ -512,9 +509,9 @@ void sortmaterials(vector<materialsurface *> &vismats)
     if(reflecting) sortorigin.z = int(reflectz - (camera1->o.z - reflectz));
     vec dir(camera1->yaw*RAD, reflecting ? -camera1->pitch : camera1->pitch);
     loopi(3) { dir[i] = fabs(dir[i]); sortdim[i] = i; }
-    if(dir[sortdim[2]] > dir[sortdim[1]]) swap(sortdim[2], sortdim[1]);
-    if(dir[sortdim[1]] > dir[sortdim[0]]) swap(sortdim[1], sortdim[0]);
-    if(dir[sortdim[2]] > dir[sortdim[1]]) swap(sortdim[2], sortdim[1]);
+    if(dir[sortdim[2]] > dir[sortdim[1]]) std::swap(sortdim[2], sortdim[1]);
+    if(dir[sortdim[1]] > dir[sortdim[0]]) std::swap(sortdim[1], sortdim[0]);
+    if(dir[sortdim[2]] > dir[sortdim[1]]) std::swap(sortdim[2], sortdim[1]);
 
     for(vtxarray *va = reflecting ? reflectedva : visibleva; va; va = reflecting ? va->rnext : va->next)
     {

--- a/src/engine/menus.cpp
+++ b/src/engine/menus.cpp
@@ -1,7 +1,4 @@
 // menus.cpp: ingame menu system (also used for scores and serverlist)
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 VAR(0, guipasses, 1, -1, -1);

--- a/src/engine/mpr.h
+++ b/src/engine/mpr.h
@@ -295,7 +295,7 @@ namespace mpr
         // If the origin is on the - side of the plane, reverse the direction of the plane
         if(n.dot(v0) > 0)
         {
-            swap(v1, v2);
+            std::swap(v1, v2);
             n.neg();
         }
 
@@ -415,9 +415,9 @@ namespace mpr
         // If the origin is on the - side of the plane, reverse the direction of the plane
         if(n.dot(v0) > 0)
         {
-            swap(v1, v2);
-            swap(v11, v21);
-            swap(v12, v22);
+            std::swap(v1, v2);
+            std::swap(v11, v21);
+            std::swap(v12, v22);
             n.neg();
         }
 

--- a/src/engine/normal.cpp
+++ b/src/engine/normal.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 struct normalgroup

--- a/src/engine/octa.cpp
+++ b/src/engine/octa.cpp
@@ -1,7 +1,4 @@
 // core world management routines
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 cube *worldroot = newcubes(F_SOLID);
@@ -1645,7 +1642,7 @@ bool mergepolys(int orient, hashset<plink> &links, vector<plink *> &queue, int o
     {
         pedge e(p.verts[prev], p.verts[j]);
         int order = e.from.x > e.to.x || (e.from.x == e.to.x && e.from.y > e.to.y) ? 1 : 0;
-        if(order) swap(e.from, e.to);
+        if(order) std::swap(e.from, e.to);
         plink &l = links.access(e, e);
         bool shouldqueue = l.polys[order] < 0 && l.polys[order^1] >= 0;
         l.polys[order] = owner;
@@ -1733,7 +1730,7 @@ void mergepolys(int orient, const ivec &co, const ivec &n, int offset, vector<po
         {
             pedge e(p.verts[prev], p.verts[j]);
             int order = e.from.x > e.to.x || (e.from.x == e.to.x && e.from.y > e.to.y) ? 1 : 0;
-            if(order) swap(e.from, e.to);
+            if(order) std::swap(e.from, e.to);
             plink &l = links.access(e, e);
             l.polys[order] = i;
             if(l.polys[0] >= 0 && l.polys[1] >= 0) queue.add(&l);

--- a/src/engine/octaedit.cpp
+++ b/src/engine/octaedit.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include <vector>
 #include "engine.h"
 
@@ -223,7 +221,7 @@ COMMAND(0, selextend, "");
 ICOMMAND(0, selmoved, "", (), { if(noedit(true)) return; intret(sel.o != savedsel.o ? 1 : 0); });
 ICOMMAND(0, selsave, "", (), { if(noedit(true)) return; savedsel = sel; });
 ICOMMAND(0, selrestore, "", (), { if(noedit(true)) return; sel = savedsel; });
-ICOMMAND(0, selswap, "", (), { if(noedit(true)) return; swap(sel, savedsel); });
+ICOMMAND(0, selswap, "", (), { if(noedit(true)) return; std::swap(sel, savedsel); });
 
 ///////// selection support /////////////
 
@@ -2613,13 +2611,13 @@ uint mflip(uint face) { return (face&0xFF0000FF) | ((face&0x00FF0000)>>8) | ((fa
 
 void flipcube(cube &c, int d)
 {
-    swap(c.texture[d*2], c.texture[d*2+1]);
+    std::swap(c.texture[d*2], c.texture[d*2+1]);
     c.faces[D[d]] = dflip(c.faces[D[d]]);
     c.faces[C[d]] = cflip(c.faces[C[d]]);
     c.faces[R[d]] = rflip(c.faces[R[d]]);
     if(c.children)
     {
-        loopi(8) if(i&octadim(d)) swap(c.children[i], c.children[i-octadim(d)]);
+        loopi(8) if(i&octadim(d)) std::swap(c.children[i], c.children[i-octadim(d)]);
         loopi(8) flipcube(c.children[i], d);
     }
 }
@@ -2634,11 +2632,11 @@ void rotatecube(cube &c, int d) // rotates cube clockwise. see pics in cvs for h
     c.faces[D[d]] = cflip (mflip(c.faces[D[d]]));
     c.faces[C[d]] = dflip (mflip(c.faces[C[d]]));
     c.faces[R[d]] = rflip (mflip(c.faces[R[d]]));
-    swap(c.faces[R[d]], c.faces[C[d]]);
+    std::swap(c.faces[R[d]], c.faces[C[d]]);
 
-    swap(c.texture[2*R[d]], c.texture[2*C[d]+1]);
-    swap(c.texture[2*C[d]], c.texture[2*R[d]+1]);
-    swap(c.texture[2*C[d]], c.texture[2*C[d]+1]);
+    std::swap(c.texture[2*R[d]], c.texture[2*C[d]+1]);
+    std::swap(c.texture[2*C[d]], c.texture[2*R[d]+1]);
+    std::swap(c.texture[2*C[d]], c.texture[2*C[d]+1]);
 
     if(c.children)
     {
@@ -2670,7 +2668,7 @@ void mpflip(selinfo &sel, bool local)
         {
             cube &a = selcube(x, y, z);
             cube &b = selcube(x, y, zs-z-1);
-            swap(a, b);
+            std::swap(a, b);
         }
     }
     changed(sel);
@@ -3003,7 +3001,7 @@ void rendertexturepanel(int w, int h)
                 float xoff = vslot.offset.x, yoff = vslot.offset.y;
                 if(vslot.rotation)
                 {
-                    if((vslot.rotation&5) == 1) { swap(xoff, yoff); loopk(4) swap(tc[k].x, tc[k].y); }
+                    if((vslot.rotation&5) == 1) { std::swap(xoff, yoff); loopk(4) std::swap(tc[k].x, tc[k].y); }
                     if(vslot.rotation >= 2 && vslot.rotation <= 4) { xoff *= -1; loopk(4) tc[k].x *= -1; }
                     if(vslot.rotation <= 2 || vslot.rotation == 5) { yoff *= -1; loopk(4) tc[k].y *= -1; }
                 }

--- a/src/engine/octarender.cpp
+++ b/src/engine/octarender.cpp
@@ -1,7 +1,4 @@
 // octarender.cpp: fill vertex arrays with different cube surfaces.
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 struct vboinfo
@@ -964,7 +961,7 @@ void gencubeedges(cube &c, const ivec &co, int size)
             if(d[axis] < 0)
             {
                 d.neg();
-                swap(e1, e2);
+                std::swap(e1, e2);
             }
             reduceslope(d);
 

--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -2,9 +2,6 @@
 // All physics computations and constants were invented on the fly and simply tweaked until
 // they "felt right", and have no basis in reality. Collision detection is simplistic but
 // very robust (uses discrete steps at fixed fps).
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 #include "mpr.h"
 

--- a/src/engine/pvs.cpp
+++ b/src/engine/pvs.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "engine.h"
 #include "SDL_thread.h"
 
@@ -440,9 +438,9 @@ struct pvsworker
             order[1] = cullorder(1, diff.x);
             order[2] = cullorder(2, diff.y);
             order[3] = cullorder(4, diff.z);
-            if(order[2].dist < order[1].dist) swap(order[1], order[2]);
-            if(order[3].dist < order[2].dist) swap(order[2], order[3]);
-            if(order[2].dist < order[1].dist) swap(order[1], order[2]);
+            if(order[2].dist < order[1].dist) std::swap(order[1], order[2]);
+            if(order[3].dist < order[2].dist) std::swap(order[2], order[3]);
+            if(order[2].dist < order[1].dist) std::swap(order[1], order[2]);
             cullorder dxy(order[1].index|order[2].index, order[1].dist+order[2].dist),
                       dxz(order[1].index|order[3].index, order[1].dist+order[3].dist),
                       dyz(order[2].index|order[3].index, order[2].dist+order[3].dist);
@@ -466,9 +464,9 @@ struct pvsworker
         shaftbb geom(co, size, edges);
         ivec diff = ivec(geom.max).sub(ivec(viewcellbb.min)).abs();
         cullorder order[3] = { cullorder(0, diff.x), cullorder(1, diff.y), cullorder(2, diff.z) };
-        if(order[1].dist > order[0].dist) swap(order[0], order[1]);
-        if(order[2].dist > order[1].dist) swap(order[1], order[2]);
-        if(order[1].dist > order[0].dist) swap(order[0], order[1]);
+        if(order[1].dist > order[0].dist) std::swap(order[0], order[1]);
+        if(order[2].dist > order[1].dist) std::swap(order[1], order[2]);
+        if(order[1].dist > order[0].dist) std::swap(order[0], order[1]);
         loopi(6)
         {
             int dim = order[i >= 3 ? i-3 : i].index, dc = (i >= 3) != (geom.max[dim] <= viewcellbb.min[dim]) ? 1 : 0, r = R[dim], c = C[dim];

--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -1,7 +1,4 @@
 // rendergl.cpp: core opengl rendering stuff
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 bool hasVAO = false, hasFBO = false, hasAFBO = false, hasDS = false, hasTF = false, hasTRG = false, hasTSW = false, hasS3TC = false, hasFXT1 = false, hasLATC = false, hasRGTC = false, hasAF = false, hasFBB = false, hasUBO = false, hasMBR = false;
@@ -1487,10 +1484,10 @@ void drawcubemap(int level, const vec &o, float yaw, float pitch, bool flipx, bo
     if(flipx || flipy) projmatrix.scalexy(flipx ? -1 : 1, flipy ? -1 : 1);
     if(swapxy)
     {
-        swap(projmatrix.a.x, projmatrix.a.y);
-        swap(projmatrix.b.x, projmatrix.b.y);
-        swap(projmatrix.c.x, projmatrix.c.y);
-        swap(projmatrix.d.x, projmatrix.d.y);
+        std::swap(projmatrix.a.x, projmatrix.a.y);
+        std::swap(projmatrix.b.x, projmatrix.b.y);
+        std::swap(projmatrix.c.x, projmatrix.c.y);
+        std::swap(projmatrix.d.x, projmatrix.d.y);
     }
     setcamprojmatrix();
 

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "engine.h"
 
 VAR(0, oqdynent, 0, 1, 1);

--- a/src/engine/renderparticles.cpp
+++ b/src/engine/renderparticles.cpp
@@ -1,7 +1,4 @@
 // renderparticles.cpp
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 #include "rendertarget.h"
 
@@ -660,8 +657,8 @@ struct varenderer : partrenderer
             #define SETTEXCOORDS(u1c, u2c, v1c, v2c) \
             { \
                 float u1 = u1c, u2 = u2c, v1 = v1c, v2 = v2c; \
-                if(p->flags&0x01) swap(u1, u2); \
-                if(p->flags&0x02) swap(v1, v2); \
+                if(p->flags&0x01) std::swap(u1, u2); \
+                if(p->flags&0x02) std::swap(v1, v2); \
                 vs[0].tc = vec2(u1, v1); \
                 vs[1].tc = vec2(u2, v1); \
                 vs[2].tc = vec2(u2, v2); \
@@ -1563,7 +1560,7 @@ static inline vec offsetvec(vec o, int dir, int dist)
         }
         else from = to = p;
 
-        if(inv) swap(from, to);
+        if(inv) std::swap(from, to);
 
         if(taper)
         {

--- a/src/engine/rendersky.cpp
+++ b/src/engine/rendersky.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "engine.h"
 
 Texture *sky[6] = { 0, 0, 0, 0, 0, 0 }, *clouds[6] = { 0, 0, 0, 0, 0, 0 };

--- a/src/engine/rendertarget.h
+++ b/src/engine/rendertarget.h
@@ -339,11 +339,11 @@ struct rendertarget
         if(blursize && !blurtex) setupblur();
         if(swaptexs() && blursize)
         {
-            swap(rendertex, blurtex);
+            std::swap(rendertex, blurtex);
             if(!rtsharefb)
             {
-                swap(renderfb, blurfb);
-                swap(renderdb, blurdb);
+                std::swap(renderfb, blurfb);
+                std::swap(renderdb, blurdb);
             }
         }
         glBindFramebuffer_(GL_FRAMEBUFFER, renderfb);
@@ -457,7 +457,7 @@ struct rendertarget
         gle::colorf(1, 1, 1);
         glBindTexture(GL_TEXTURE_2D, rendertex);
         float tx1 = 0, tx2 = 1, ty1 = 0, ty2 = 1;
-        if(flipdebug()) swap(ty1, ty2);
+        if(flipdebug()) std::swap(ty1, ty2);
         hudquad(0, 0, w, h, tx1, ty1, tx2-tx1, ty2-ty1);
         hudnotextureshader->set();
         dodebug(w, h);

--- a/src/engine/rendertext.cpp
+++ b/src/engine/rendertext.cpp
@@ -1,7 +1,5 @@
 #include <vector>
 #include <string>
-#include <algorithm>
-using std::swap;
 #include "engine.h"
 
 VAR(IDF_PERSIST, textblinking, 0, 250, VAR_MAX);

--- a/src/engine/renderva.cpp
+++ b/src/engine/renderva.cpp
@@ -1,7 +1,4 @@
 // renderva.cpp: handles the occlusion and rendering of vertex arrays
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 static inline void drawtris(GLsizei numindices, const GLvoid *indices, ushort minvert, ushort maxvert)
@@ -1226,7 +1223,7 @@ static void changetexgen(renderstate &cur, int dim, Slot &slot, VSlot &vslot)
             float xs = vslot.rotation>=2 && vslot.rotation<=4 ? -tex->xs : tex->xs,
                   ys = (vslot.rotation>=1 && vslot.rotation<=2) || vslot.rotation==5 ? -tex->ys : tex->ys;
             vec2 scroll(vslot.scroll);
-            if((vslot.rotation&5)==1) swap(scroll.x, scroll.y);
+            if((vslot.rotation&5)==1) std::swap(scroll.x, scroll.y);
             scroll.x *= lastmillis*tex->xs/xs;
             scroll.y *= lastmillis*tex->ys/ys;
             if(cur.texgenscroll != scroll)

--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -1,9 +1,6 @@
 // server.cpp: little more than enhanced multicaster
 // runs dedicated or as client coroutine
 
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 #include <signal.h>
 

--- a/src/engine/serverbrowser.cpp
+++ b/src/engine/serverbrowser.cpp
@@ -1,7 +1,4 @@
 // serverbrowser.cpp: eihrul's concurrent resolver, and server browser window management
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 #include "SDL_thread.h"
 

--- a/src/engine/shader.cpp
+++ b/src/engine/shader.cpp
@@ -1,7 +1,4 @@
 // shader.cpp: OpenGL GLSL shader management
-#include <algorithm>
-using std::swap;
-
 #include "engine.h"
 
 Shader *Shader::lastshader = NULL;

--- a/src/engine/shadowmap.cpp
+++ b/src/engine/shadowmap.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include <vector>
 #include "engine.h"
 #include "rendertarget.h"

--- a/src/engine/sound.cpp
+++ b/src/engine/sound.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "engine.h"
 #include "SDL_mixer.h"
 

--- a/src/engine/textedit.h
+++ b/src/engine/textedit.h
@@ -259,8 +259,8 @@ struct editor
         sy = (mx >= 0) ? my : cy;
         ex = cx;
         ey = cy;
-        if(sy > ey) { swap(sy, ey); swap(sx, ex); }
-        else if(sy == ey && sx > ex) swap(sx, ex);
+        if(sy > ey) { std::swap(sy, ey); std::swap(sx, ex); }
+        else if(sy == ey && sx > ex) std::swap(sx, ex);
         return (sx != ex) || (sy != ey);
     }
 

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -1,7 +1,5 @@
 // texture.cpp: texture slot management
 
-#include <algorithm>
-using std::swap;
 #include "engine.h"
 #include "SDL_image.h"
 
@@ -85,7 +83,7 @@ static void reorientnormals(uchar * RESTRICT src, int sw, int sh, int bpp, int s
             uchar nx = *src++, ny = *src++;
             if(flipx) nx = 255-nx;
             if(flipy) ny = 255-ny;
-            if(swapxy) swap(nx, ny);
+            if(swapxy) std::swap(nx, ny);
             curdst[0] = nx;
             curdst[1] = ny;
             curdst[2] = *src++;
@@ -142,7 +140,7 @@ static void reorients3tc(GLenum format, int blocksize, int w, int h, uchar *src,
             {
                 ullong salpha = lilswap(*(const ullong *)src), dalpha = 0;
                 uint xmask = flipx ? 15 : 0, ymask = flipy ? 15 : 0, xshift = 2, yshift = 4;
-                if(swapxy) swap(xshift, yshift);
+                if(swapxy) std::swap(xshift, yshift);
                 for(int y = by1; y < by2; y++) for(int x = bx1; x < bx2; x++)
                 {
                     dalpha |= ((salpha&15) << (((xmask^x)<<xshift) + ((ymask^y)<<yshift)));
@@ -157,7 +155,7 @@ static void reorients3tc(GLenum format, int blocksize, int w, int h, uchar *src,
                 uchar alpha1 = src[0], alpha2 = src[1];
                 ullong salpha = lilswap(*(const ushort *)&src[2]) + ((ullong)lilswap(*(const uint *)&src[4]) << 16), dalpha = 0;
                 uint xmask = flipx ? 7 : 0, ymask = flipy ? 7 : 0, xshift = 0, yshift = 2;
-                if(swapxy) swap(xshift, yshift);
+                if(swapxy) std::swap(xshift, yshift);
                 for(int y = by1; y < by2; y++) for(int x = bx1; x < bx2; x++)
                 {
                     dalpha |= ((salpha&7) << (3*((xmask^x)<<xshift) + ((ymask^y)<<yshift)));
@@ -196,7 +194,7 @@ static void reorients3tc(GLenum format, int blocksize, int w, int h, uchar *src,
                 else { color1 = ncolor1; color2 = ncolor2; }
             }
             uint dbits = 0, xmask = flipx ? 3 : 0, ymask = flipy ? 3 : 0, xshift = 1, yshift = 3;
-            if(swapxy) swap(xshift, yshift);
+            if(swapxy) std::swap(xshift, yshift);
             for(int y = by1; y < by2; y++) for(int x = bx1; x < bx2; x++)
             {
                 dbits |= ((sbits&3) << (((xmask^x)<<xshift) + ((ymask^y)<<yshift)));
@@ -228,7 +226,7 @@ static void reorientrgtc(GLenum format, int blocksize, int w, int h, uchar *src,
                 uchar val1 = src[0], val2 = src[1];
                 ullong sval = lilswap(*(const ushort *)&src[2]) + ((ullong)lilswap(*(const uint *)&src[4] )<< 16), dval = 0;
                 uint xmask = flipx ? 7 : 0, ymask = flipy ? 7 : 0, xshift = 0, yshift = 2;
-                if(swapxy) swap(xshift, yshift);
+                if(swapxy) std::swap(xshift, yshift);
                 for(int y = by1; y < by2; y++) for(int x = bx1; x < bx2; x++)
                 {
                     dval |= ((sval&7) << (3*((xmask^x)<<xshift) + ((ymask^y)<<yshift)));
@@ -1696,7 +1694,7 @@ int compactvslots(bool cull)
     loopv(vslots)
     {
         while(vslots[i]->index >= 0 && vslots[i]->index != i)
-            swap(vslots[i], vslots[vslots[i]->index]);
+            std::swap(vslots[i], vslots[vslots[i]->index]);
     }
     for(int i = compactedvslots; i < vslots.length(); i++) delete vslots[i];
     vslots.setsize(compactedvslots);
@@ -1721,7 +1719,7 @@ static void clampvslotoffset(VSlot &dst, Slot *slot = NULL)
         Texture *t = slot->sts[0].t;
         int xs = t->xs, ys = t->ys;
         if(t->type & Texture::MIRROR) { xs *= 2; ys *= 2; }
-        if((dst.rotation&5)==1) swap(xs, ys);
+        if((dst.rotation&5)==1) std::swap(xs, ys);
         dst.offset.x %= xs; if(dst.offset.x < 0) dst.offset.x += xs;
         dst.offset.y %= ys; if(dst.offset.y < 0) dst.offset.y += ys;
     }
@@ -2780,12 +2778,12 @@ GLuint genenvmap(const vec &o, int envmapsize, int blur)
         if(rendersize > texsize)
         {
             scaletexture(src, rendersize, rendersize, 3, 3*rendersize, dst, texsize, texsize);
-            swap(src, dst);
+            std::swap(src, dst);
         }
         if(blur > 0)
         {
             blurtexture(blur, 3, texsize, texsize, dst, src);
-            swap(src, dst);
+            std::swap(src, dst);
         }
         createtexture(tex, texsize, texsize, src, 3, 2, GL_RGB5, side.target);
     }

--- a/src/engine/ui.cpp
+++ b/src/engine/ui.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include <vector>
 #include "engine.h"
 
@@ -980,7 +978,7 @@ struct gui : guient
         int xoff = vslot.offset.x, yoff = vslot.offset.y;
         if(vslot.rotation)
         {
-            if((vslot.rotation&5) == 1) { swap(xoff, yoff); loopk(4) swap(tc[k].x, tc[k].y); }
+            if((vslot.rotation&5) == 1) { std::swap(xoff, yoff); loopk(4) std::swap(tc[k].x, tc[k].y); }
             if(vslot.rotation >= 2 && vslot.rotation <= 4) { xoff *= -1; loopk(4) tc[k].x *= -1; }
             if(vslot.rotation <= 2 || vslot.rotation == 5) { yoff *= -1; loopk(4) tc[k].y *= -1; }
         }

--- a/src/engine/water.cpp
+++ b/src/engine/water.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include <vector>
 #include "engine.h"
 

--- a/src/engine/world.cpp
+++ b/src/engine/world.cpp
@@ -1,11 +1,8 @@
 // world.cpp: core map management stuff
-#include <algorithm>
 #include <string>
-using std::swap;
+#include <vector>
 
 #include "engine.h"
-
-#include <vector>
 
 mapz hdr;
 int worldscale;
@@ -427,7 +424,7 @@ void entrotate(int *cw)
     groupeditundo(
         e.o[dd] -= (e.o[dd]-mid)*2;
         e.o.sub(s);
-        swap(e.o[R[d]], e.o[C[d]]);
+        std::swap(e.o[R[d]], e.o[C[d]]);
         e.o.add(s);
     );
 }

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include <vector>
 // worldio.cpp: loading & saving of maps
 
@@ -445,13 +443,13 @@ void loadc(stream *f, cube &c, const ivec &co, int size, bool &failed)
         if(hdr.version <= 8) edgespan2vectorcube(c);
         if(hdr.version <= 11)
         {
-            swap(c.faces[0], c.faces[2]);
-            swap(c.texture[0], c.texture[4]);
-            swap(c.texture[1], c.texture[5]);
+            std::swap(c.faces[0], c.faces[2]);
+            std::swap(c.texture[0], c.texture[4]);
+            std::swap(c.texture[1], c.texture[5]);
             if(hassurfs&0x33)
             {
-                swap(surfaces[0], surfaces[4]);
-                swap(surfaces[1], surfaces[5]);
+                std::swap(surfaces[0], surfaces[4]);
+                std::swap(surfaces[1], surfaces[5]);
                 hassurfs = (hassurfs&~0x33) | ((hassurfs&0x30)>>4) | ((hassurfs&0x03)<<4);
             }
         }

--- a/src/game/ai.cpp
+++ b/src/game/ai.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace ai
 {

--- a/src/game/bomber.cpp
+++ b/src/game/bomber.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace bomber
 {

--- a/src/game/capture.cpp
+++ b/src/game/capture.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace capture
 {

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1,7 +1,5 @@
 #include <vector>
 #include <string>
-#include <algorithm>
-using std::swap;
 #include "game.h"
 
 namespace client

--- a/src/game/defend.cpp
+++ b/src/game/defend.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace defend
 {

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace entities
 {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1,7 +1,5 @@
-#include <algorithm>
 #include <vector>
 #include <string>
-using std::swap;
 #include <vector>
 #define GAMEWORLD 1
 #include "game.h"
@@ -3123,7 +3121,7 @@ namespace game
                 case ANIM_RIFLE: case ANIM_GRENADE: case ANIM_MINE: case ANIM_ROCKET:
                 {
                     anim = (anim>>ANIM_SECONDARY) | ((anim&((1<<ANIM_SECONDARY)-1))<<ANIM_SECONDARY);
-                    swap(basetime, basetime2);
+                    std::swap(basetime, basetime2);
                     break;
                 }
                 default: break;

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include <vector>
 #include "game.h"
 
@@ -818,8 +816,8 @@ namespace hud
 
     void drawquad(float x, float y, float w, float h, float tx1, float ty1, float tx2, float ty2, bool flipx, bool flipy)
     {
-        if(flipx) swap(tx1, tx2);
-        if(flipy) swap(ty1, ty2);
+        if(flipx) std::swap(tx1, tx2);
+        if(flipy) std::swap(ty1, ty2);
         gle::defvertex(2);
         gle::deftexcoord0();
         gle::begin(GL_TRIANGLE_STRIP);

--- a/src/game/physics.cpp
+++ b/src/game/physics.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace physics
 {

--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace projs
 {

--- a/src/game/scoreboard.cpp
+++ b/src/game/scoreboard.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 
 namespace hud

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -23,10 +23,8 @@
 // for use on the master server should first seek permission from the Blue Nebula Team,
 // each modification must be approved and will be done on a case-by-case basis.
 
-#include <algorithm>
 #include <vector>
 #include <string>
-using std::swap;
 
 #define GAMESERVER 1
 #include "game.h"

--- a/src/game/waypoint.cpp
+++ b/src/game/waypoint.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "game.h"
 
 extern selinfo sel;
@@ -111,7 +109,7 @@ namespace ai
                 else
                 {
                     --right;
-                    swap(indices[left], indices[right]);
+                    std::swap(indices[left], indices[right]);
                     splitright = min(splitright, w.o[axis]-radius);
                     rightmin.min(vec(w.o).sub(radius));
                     rightmax.max(vec(w.o).add(radius));

--- a/src/game/weapons.cpp
+++ b/src/game/weapons.cpp
@@ -1,7 +1,5 @@
 #include <vector>
 #include <string>
-#include <algorithm>
-using std::swap;
 #include "game.h"
 namespace weapons
 {

--- a/src/shared/crypto.cpp
+++ b/src/shared/crypto.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "cube.h"
 
 ///////////////////////// cryptography /////////////////////////////////
@@ -154,7 +151,7 @@ namespace tiger
             loopk(3)
             {
                 uchar *c = &val.bytes[k*sizeof(chunk)];
-                loopl(sizeof(chunk)/2) swap(c[l], c[sizeof(chunk)-1-l]);
+                loopl(sizeof(chunk)/2) std::swap(c[l], c[sizeof(chunk)-1-l]);
             }
         }
     }

--- a/src/shared/geom.cpp
+++ b/src/shared/geom.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "cube.h"
 
 void vecfromyawpitch(float yaw, float pitch, int move, int strafe, vec &m)

--- a/src/shared/geom.h
+++ b/src/shared/geom.h
@@ -619,8 +619,8 @@ struct matrix3
 
     void transpose()
     {
-        swap(a.y, b.x); swap(a.z, c.x);
-        swap(b.z, c.y);
+        std::swap(a.y, b.x); std::swap(a.z, c.x);
+        std::swap(b.z, c.y);
     }
 
     template<class M>
@@ -906,8 +906,8 @@ struct matrix4x3
     void transpose()
     {
         d = vec(a.dot(d), b.dot(d), c.dot(d)).neg();
-        swap(a.y, b.x); swap(a.z, c.x);
-        swap(b.z, c.y);
+        std::swap(a.y, b.x); std::swap(a.z, c.x);
+        std::swap(b.z, c.y);
     }
 
     void transpose(const matrix4x3 &o)
@@ -1647,9 +1647,9 @@ struct matrix4
 
     void transpose()
     {
-        swap(a.y, b.x); swap(a.z, c.x); swap(a.w, d.x);
-        swap(b.z, c.y); swap(b.w, d.y);
-        swap(c.w, d.z);
+        std::swap(a.y, b.x); std::swap(a.z, c.x); std::swap(a.w, d.x);
+        std::swap(b.z, c.y); std::swap(b.w, d.y);
+        std::swap(c.w, d.z);
     }
 
     void transpose(const matrix4 &m)

--- a/src/shared/glemu.cpp
+++ b/src/shared/glemu.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-using std::swap;
 #include "cube.h"
 
 extern int glversion;

--- a/src/shared/stream.cpp
+++ b/src/shared/stream.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "cube.h"
 
 ///////////////////////// character conversion ///////////////

--- a/src/shared/tools.cpp
+++ b/src/shared/tools.cpp
@@ -1,8 +1,5 @@
 // implementation of generic tools
 
-#include <algorithm>
-using std::swap;
-
 #include "cube.h"
 
 ////////////////////////// rnd numbers ////////////////////////////////////////

--- a/src/shared/tools.h
+++ b/src/shared/tools.h
@@ -469,13 +469,13 @@ static inline void quicksort(T *start, T *end, F fun)
         }
         else if(fun(*start, end[-1])) { pivot = *start; *start = *mid; } /*mid <= start < end */
         else if(fun(*mid, end[-1])) { pivot = end[-1]; end[-1] = *start; *start = *mid; } /* mid < end <= start */
-        else { pivot = *mid; swap(*start, end[-1]); }  /* end <= mid <= start */
+        else { pivot = *mid; std::swap(*start, end[-1]); }  /* end <= mid <= start */
         *mid = end[-2];
         do
         {
             while(fun(*i, pivot)) if(++i >= j) goto partitioned;
             while(fun(pivot, *--j)) if(i >= j) goto partitioned;
-            swap(*i, *j);
+            std::swap(*i, *j);
         }
         while(++i < j);
     partitioned:
@@ -739,9 +739,9 @@ public:
     {
         if(!ulen)
         {
-            swap(buf, v.buf);
-            swap(ulen, v.ulen);
-            swap(alen, v.alen);
+            std::swap(buf, v.buf);
+            std::swap(ulen, v.ulen);
+            std::swap(alen, v.alen);
         }
         else
         {
@@ -909,7 +909,7 @@ public:
 
     void reverse()
     {
-        loopi(ulen/2) swap(buf[i], buf[ulen-1-i]);
+        loopi(ulen/2) std::swap(buf[i], buf[ulen-1-i]);
     }
 
     static int heapparent(int i) { return (i - 1) >> 1; }
@@ -927,7 +927,7 @@ public:
         {
             int pi = heapparent(i);
             if(score >= heapscore(buf[pi])) break;
-            swap(buf[i], buf[pi]);
+            std::swap(buf[i], buf[pi]);
             i = pi;
         }
         return i;
@@ -949,10 +949,10 @@ public:
             float cscore = heapscore(buf[ci]);
             if(score > cscore)
             {
-               if(ci+1 < ulen && heapscore(buf[ci+1]) < cscore) { swap(buf[ci+1], buf[i]); i = ci+1; }
-               else { swap(buf[ci], buf[i]); i = ci; }
+               if(ci+1 < ulen && heapscore(buf[ci+1]) < cscore) { std::swap(buf[ci+1], buf[i]); i = ci+1; }
+               else { std::swap(buf[ci], buf[i]); i = ci; }
             }
-            else if(ci+1 < ulen && heapscore(buf[ci+1]) < score) { swap(buf[ci+1], buf[i]); i = ci+1; }
+            else if(ci+1 < ulen && heapscore(buf[ci+1]) < score) { std::swap(buf[ci+1], buf[i]); i = ci+1; }
             else break;
         }
         return i;

--- a/src/shared/zip.cpp
+++ b/src/shared/zip.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-using std::swap;
-
 #include "cube.h"
 
 extern size_t fixdir(char *dir);


### PR DESCRIPTION
This helps clean up the code files' headers a bit, as in a lot of headers, we've had to have "using std::swap;" in almost all code files before including other headers (mainly tool.h).

The refactoring was performed mostly by my IDE's search-and-replace feature. I've read all changes again in the diff to make sure I don't introduce issues.