### PR TITLE
Fix segmentation fault when changing map

### DIFF
--- a/src/shared/tools.h
+++ b/src/shared/tools.h
@@ -216,12 +216,13 @@ inline char *newstring(size_t l)                { return new char[l+1]; }
 inline char *newstring(const char *s, size_t l) { return copystring(newstring(l), s, l+1); }
 inline char *newstring(const char *s)           { if(!s) s = ""; size_t l = strlen(s); char *d = newstring(l); memcpy(d, s, l+1); return d; }
 
-#define loopv(v)     for(decltype((v).size()) i = 0; i<(v).size(); i++)
-#define loopvj(v)    for(decltype((v).size()) j = 0; j<(v).size(); j++)
-#define loopvk(v)    for(decltype((v).size()) k = 0; k<(v).size(); k++)
-#define loopvrev(v)  for(decltype((v).size()-1) i = (v).size()-1; i>=0; i--)
-#define loopvjrev(v) for(decltype((v).size()-1) j = (v).size()-1; j>=0; j--)
-#define loopvkrev(v) for(decltype((v).size()-1) k = (v).size()-1; k>=0; k--)
+// TODO: remove macros and replace them with actual for loops
+#define loopv(v)     for(decltype((v).size()) i = 0; i < (v).size(); i++)
+#define loopvj(v)    for(decltype((v).size()) j = 0; j < (v).size(); j++)
+#define loopvk(v)    for(decltype((v).size()) k = 0; k < (v).size(); k++)
+#define loopvrev(v)  for(ssize_t i = (v).size() - 1; i >= 0; i--)
+#define loopvjrev(v) for(ssize_t j = (v).size() - 1; j >= 0; j--)
+#define loopvkrev(v) for(ssize_t k = (v).size() - 1; k >= 0; k--)
 
 template <class T>
 struct databuf


### PR DESCRIPTION
This bug was introduced in commit 9b4d1185b902e830d6eabad6d001d715c24e7ae0

The reason that the segfault happens is that when one of these loops are
used with a std::vector, the size() returns an unsigned value and `i` will
therefore be unsigned and `i>=0` will always be true.  That will cause `i`
to underflow and when used as index to an array, that's how the segfault
happens.

Steps to reproduce the bug:
Change map three times, e.g. with the following commands:
```
/dm echo
/dm cargo
/dm echo
```