### PR TITLE
Add Force Vote (Veto) Button back to map selector

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -776,13 +776,57 @@ newgui maps [ ui_stay_open [ octapaks [
     ui_strut 0.5
     ui_font super [
         ui_center [
+            show_force_button = 0
+            if (&& (getclientpriv $getclientnum $vetolock) (=s (getmastermode 1) "veto")) [
+                show_force_button = 1
+            ]
+
+
             if (&& (>= $chosenmode 0) (stringlen $chosenmap)) [
-                ui_button (? (isonline) "^fgVote" "^fgPlay")  [if (isonline) [showgui maps 2]; (? (= (gamemode) 1) (savewarnchk [start $chosenmap $chosenmode (chosenmuts)]) (start $chosenmap $chosenmode (chosenmuts))); mapsearch = ""]
+                ui_button (? (isonline) "^fgVote" "^fgPlay") [
+                    if (isonline) [
+                        showgui maps 2
+                    ]
+                    if (= (gamemode) 1) [
+                        savewarnchk [ start $chosenmap $chosenmode (chosenmuts)]
+                    ] [
+                        start $chosenmap $chosenmode (chosenmuts)
+                    ]
+                    mapsearch = ""
+                ]
+
+                if $show_force_button [
+                    ui_strut 1.5
+                    ui_button "^fzwyForce" [
+                        if (isonline) [
+                            showgui maps 2
+                        ]
+                        if (= (gamemode 1) [
+                            savewarnchk [ mapsexec $chosenmap $chosenmode (chosenmuts) ]
+                        ] [
+                            mapsexec $chosenmap $chosenmode (chosenmuts)
+                        ]
+                        mapsearch = ""
+                    ]
+                ]
             ] [
                 ui_text (? (isonline) "^fdVote" "^fdPlay")
+
+                if $show_force_button [
+                    ui_strut 1.5
+                    ui_text "^fdForce"
+                ]
             ]
         ]
     ]
+    ui_font "little" [ ui_center [
+        if (&& (isonline) (getclientpriv $getclientnum $masterlock) (!=s (getmastermode 1) "veto")) [
+            ui_button (format "Change mastermode from ^fg%1 ^fwto ^fzwyveto" (getmastermode 1)) [
+                mastermode (! (getmastermode))
+            ]
+        ]
+    ] ]
+
     ui_visible [
         cases (at $guirolloveraction 0
         ) "chosenmode" [


### PR DESCRIPTION
The veto button was forgotten in our new map selector menu, thus I added it back in:

![first](https://user-images.githubusercontent.com/37220464/88477609-e335d000-cf41-11ea-9fbd-84d2a1eed727.png)

![second](https://user-images.githubusercontent.com/37220464/88477620-f2b51900-cf41-11ea-8170-ea83104deb8b.png)

![third](https://user-images.githubusercontent.com/37220464/88477635-06f91600-cf42-11ea-8dbd-0c6e0a1e8186.png)
No worries, the screenshot was just taken at a bad moment, the Force button is actually blinking like it did before

