### PR TITLE
Clear server browser search bar when opened

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -69,6 +69,7 @@ initialise_server_menu = [
     serverinfo_retry = ""
     serverinfo_password = ""
     serverinfo_players = 0
+    serverinfo_search_str = ""
     serverinfo_servers = 0
     serverinfo_server_count = 0
     serverinfo_ui_time = (getmillis 1)


### PR DESCRIPTION
I suggest that we clear the search bar in the server browser when you open that menu.

Because when I search for a server and then join one, next time I open server browser I usually want to see all servers again.