### PR TITLE
Search variables using multiple words

### DIFF
--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -83,7 +83,10 @@ menu_variables =  [
                             q = (+ $variable_index $i)
                             if (< $q $numvars) [
                                 curvar = (getvarinfo $q $variable_types $variable_no_types $variable_flags $variable_no_flags $variable_search_text)
-                                hilvar = (stringreplace $curvar $variable_search_text (format "^fs^fy%1^fS" $variable_search_text))
+                                hilvar = $curvar
+                                looplist variable_search_word $variable_search_text [
+                                    hilvar = (stringreplace $hilvar $variable_search_word (format "^fs^fy%1^fS" $variable_search_word))
+                                ]
                                 ui_list [ ui_radiobutton $hilvar variable_number $q ]
                             ] [ ui_strut 1 ]
                         ]

--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -3579,11 +3579,24 @@ void getvarinfo(int n, int types, int notypes, int flags, int noflags, char *str
     }
     if(str && *str)
     {
+        std::vector<std::string> words;
+        explodelist(str, words);
         static char *laststr = NULL;
         if(ids[1].empty() || !laststr || strcmp(str, laststr))
         {
             ids[1].setsize(0);
-            loopv(ids[0]) if(rigcasestr(ids[0][i]->name, str)) ids[1].add(ids[0][i]);
+            loopv(ids[0])
+            {
+                bool matches = true;
+                for (const std::string &word : words)
+                {
+                    if(!rigcasestr(ids[0][i]->name, word.c_str()))
+                    {
+                        matches = false;
+                    }
+                }
+                if(matches) ids[1].add(ids[0][i]);
+            }
             if(laststr) DELETEA(laststr);
             laststr = newstring(str);
         }


### PR DESCRIPTION
This makes is possible to search using multiple words in the vars menu.
When you do that you will find all variables that contain all of the
specified words in any order.

Examples:

If you search for "weap rifle" you will find:
- riflefragweap1
- riflefragweap2
- weapidxrifle

If you search for "plasma 1" you will find all variables that modify
plasma 1.