### PR TITLE
Change ui commands that were not found

### DIFF
--- a/config/menus/help.cfg
+++ b/config/menus/help.cfg
@@ -98,7 +98,7 @@ new_ui support [
         ui_strut 0.5
         ui_center [ ui_text "Are you sure you wish to continue?" ]
         ui_strut 0.5
-        ui_center [ ui_stay_openn [
+        ui_center [ ui_stay_open [
             ui_button "^fgYES, continue" [livesupport = 1; ircaddclient freenode irc.freenode.net 6667 (getplayername); ircaddchan freenode #blue-nebula ]
             ui_spring 1
             ui_button "^foNO, go back" [clear_ui 1]
@@ -1122,8 +1122,8 @@ new_ui rules [
     ui_strut 0.5
     ui_center [
         ui_editor doc/guidelines.txt -80 15
-        textinit doc/guidelines.txt doc/guidelines.txt
-        textmode 4
+        ui_textinit doc/guidelines.txt doc/guidelines.txt
+        ui_textmode 4
     ]
     ui_strut 1
 ]


### PR DESCRIPTION
When you click "live support" or "rules" in the help menu you get error messages about commands not found. This fixes that.