### PR TITLE
Don't use fonts that don't exist

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -69,7 +69,7 @@ saveslideindexlist = [    //saves the actual guislide index in the list
 
 modevar = [
     local g m s
-    ui_stay_open [ ui_list [ ui_font "normal" [
+    ui_stay_open [ ui_list [ ui_font "default" [
         g = $arg4
         m = $$arg3
         s = $$arg5
@@ -685,7 +685,7 @@ newgui maps [ ui_stay_open [ octapaks [
                 ui_list [
                     ui_text "^fbMode"
                     ui_strut 1
-                    ui_font medium [
+                    ui_font "default" [
                         loop z $modeidxnum [
                             if (&& (!= $servertype 1) (= $z 0) (isonline)) [
                                 if (= $chosenmode 0) [
@@ -723,7 +723,7 @@ newgui maps [ ui_stay_open [ octapaks [
                     ui_list [
                         ui_text "^fbMutators"
                         ui_strut 0.5
-                        ui_font medium [
+                        ui_font "default" [
                             count = (- $mutsidxnum $mutsidxgsn)
                             ui_loop_split n 3 $count [
                                 mutsvar (at $mutsname $n) chosenmode chosenmuts (<< 1 $n) chosenmap

--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1174,7 +1174,7 @@ display_options = [
             ui_strut 0.5
             
             ui_list [
-                ui_font "normal" [           ui_text "Gamma"               ]; ui_strut 0.5
+                ui_font "default" [          ui_text "Gamma"               ]; ui_strut 0.5
                 ui_center [ ui_font "tiny" [ ui_text "^fa(Default: 100)" ] ]
             ]
             ui_slider gamma
@@ -1182,7 +1182,7 @@ display_options = [
             ui_strut 1
             
             ui_list [ 
-                ui_font "normal" [           ui_text "Full-Scene Anti-Aliasing" ]; ui_strut 0.5
+                ui_font "default" [          ui_text "Full-Scene Anti-Aliasing" ]; ui_strut 0.5
                 ui_center [ ui_font "tiny" [ ui_text "^fa(Default: -1)"       ] ]
             ]
             ui_list_slider fsaa "-1 0 2 4 8 16"
@@ -1190,7 +1190,7 @@ display_options = [
             ui_strut 0.25
             
             ui_list [
-                ui_font "normal" [           ui_text "Z-Buffer Depth"    ]; ui_strut 0.5
+                ui_font "default" [          ui_text "Z-Buffer Depth"    ]; ui_strut 0.5
                 ui_center [ ui_font "tiny" [ ui_text "^fa(Default: 0)" ] ]
             ]
             ui_list_slider depthbits "0 16 24 32"
@@ -1198,7 +1198,7 @@ display_options = [
             ui_strut 0.25
             
             ui_list [ 
-                ui_font "normal" [           ui_text "Anisotropic Filtering" ]; ui_strut 0.5
+                ui_font "default" [          ui_text "Anisotropic Filtering" ]; ui_strut 0.5
                 ui_center [ ui_font "tiny" [ ui_text "^fa(Default: 0)"     ] ]
             ]
             ui_list_slider anisotropy "0 2 4 8 16"


### PR DESCRIPTION
You may have noticed that the maps menu or the graphics options suddenly change font size a few seconds after you open it while playing. This is because we were using fonts that don't exist, like "medium" and "normal". I changed them to "default".

Maybe we should handle it better when fonts don't exist (show error message?) but that's another PR.