### PR TITLE
Reset slider to 0 in controls menu

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1040,6 +1040,7 @@ editbindtitles = [
 ]
 
 curbindtype = 0
+prevbindtype = $curbindtype
 curbindshow = 1
 
 new_ui resetcontrols [
@@ -1723,6 +1724,10 @@ keyboard_options = [
                 ui_text "state:"
                 ui_strut 1
                 loop i 4 [ ui_radiobutton (at $bindtypes $i) curbindtype $i; ui_strut 2 ]
+                if (!= $curbindtype $prevbindtype) [
+                    slider = 0  // this value is used inside ui_loop_scrollbar below
+                    prevbindtype = $curbindtype
+                ]
                 //ui_checkbox "show default bind if not found" curbindshow
             ]
             ui_strut 1


### PR DESCRIPTION
This fixes a bug where the scroll area would show too much stuff if you
scroll to the bottom of "default" and then click "spectator".  It also
makes the scroll area behave more like other ones in the game (they
reset when you change their content).

Screenshot of bug:
![Screenshot](https://user-images.githubusercontent.com/1399719/88643604-2fa81980-d0c2-11ea-84f1-5bb9beb537d0.png)