### PR TITLE
Fix game crash when burndelay is 0 bug

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3615,7 +3615,7 @@ namespace game
             // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
             int _burndelay = std::max(burndelay, 1);
             if(burntime - millis < _burndelay) pc *= float(burntime - millis) / _burndelay;
-            else pc *= 0.75f + (float(millis % _burndelay) / float(_burndelay * 4);
+            else pc *= 0.75f + (float(millis % _burndelay) / float(_burndelay * 4));
             vec pos = vec(d->center()).sub(vec(rnd(11)-5, rnd(11)-5, rnd(5)-2).mul(pc));
             regular_part_create(PART_FIREBALL, 50, pos, pulsecols[PULSE_FIRE][rnd(PULSECOLOURS)], d->height*0.75f*intensity*blend*pc, fade*blend*pc, -10, 0);
         }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -935,10 +935,12 @@ namespace game
                     int millis = lastmillis-d->lastres[WR_BURN];
                     size_t seed = size_t(d) + (millis/50);
                     float pc = 1, amt = (millis%50)/50.0f, intensity = 0.75f+(detrnd(seed, 25)*(1-amt) + detrnd(seed + 1, 25)*amt)/100.f;
-                    if(burntime-millis < burndelay) pc *= float(burntime-millis)/float(burndelay);
+                    // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+                    int _burndelay = std::max(burndelay, 1);
+                    if(burntime-millis < _burndelay) pc *= float(burntime - millis) / float(_burndelay);
                     else
                     {
-                        float fluc = float(millis%burndelay)*(0.25f+0.03f)/burndelay;
+                        float fluc = float(millis % _burndelay) * (0.25f + 0.03f) / _burndelay;
                         if(fluc >= 0.25f) fluc = (0.25f+0.03f-fluc)*(0.25f/0.03f);
                         pc *= 0.75f+fluc;
                     }
@@ -3610,8 +3612,10 @@ namespace game
         {
             int millis = lastmillis-d->lastres[WR_BURN];
             float pc = 1, intensity = 0.5f+(rnd(50)/100.f), fade = (d != focus ? 0.5f : 0.f)+(rnd(50)/100.f);
-            if(burntime-millis < burndelay) pc *= float(burntime-millis)/float(burndelay);
-            else pc *= 0.75f+(float(millis%burndelay)/float(burndelay*4));
+            // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+            int _burndelay = std::max(burndelay, 1);
+            if(burntime - millis < _burndelay) pc *= float(burntime - millis) / _burndelay;
+            else pc *= 0.75f + (float(millis % _burndelay) / float(_burndelay * 4);
             vec pos = vec(d->center()).sub(vec(rnd(11)-5, rnd(11)-5, rnd(5)-2).mul(pc));
             regular_part_create(PART_FIREBALL, 50, pos, pulsecols[PULSE_FIRE][rnd(PULSECOLOURS)], d->height*0.75f*intensity*blend*pc, fade*blend*pc, -10, 0);
         }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -935,7 +935,7 @@ namespace game
                     int millis = lastmillis-d->lastres[WR_BURN];
                     size_t seed = size_t(d) + (millis/50);
                     float pc = 1, amt = (millis%50)/50.0f, intensity = 0.75f+(detrnd(seed, 25)*(1-amt) + detrnd(seed + 1, 25)*amt)/100.f;
-                    // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+                    // When playing on servers with an older version, burndelay can be 0, thus avoid division by zero by enforcing new lower boundary
                     int fixed_burndelay = std::max(burndelay, 1);
                     if(burntime-millis < fixed_burndelay) pc *= float(burntime - millis) / float(fixed_burndelay);
                     else
@@ -3612,7 +3612,7 @@ namespace game
         {
             int millis = lastmillis-d->lastres[WR_BURN];
             float pc = 1, intensity = 0.5f+(rnd(50)/100.f), fade = (d != focus ? 0.5f : 0.f)+(rnd(50)/100.f);
-            // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+            // When playing on servers with an older version, burndelay can be 0, thus avoid division by zero by enforcing new lower boundary
             int fixed_burndelay = std::max(burndelay, 1);
             if(burntime - millis < fixed_burndelay) pc *= float(burntime - millis) / fixed_burndelay;
             else pc *= 0.75f + (float(millis % fixed_burndelay) / float(fixed_burndelay * 4));

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -936,11 +936,11 @@ namespace game
                     size_t seed = size_t(d) + (millis/50);
                     float pc = 1, amt = (millis%50)/50.0f, intensity = 0.75f+(detrnd(seed, 25)*(1-amt) + detrnd(seed + 1, 25)*amt)/100.f;
                     // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
-                    int _burndelay = std::max(burndelay, 1);
-                    if(burntime-millis < _burndelay) pc *= float(burntime - millis) / float(_burndelay);
+                    int fixed_burndelay = std::max(burndelay, 1);
+                    if(burntime-millis < fixed_burndelay) pc *= float(burntime - millis) / float(fixed_burndelay);
                     else
                     {
-                        float fluc = float(millis % _burndelay) * (0.25f + 0.03f) / _burndelay;
+                        float fluc = float(millis % fixed_burndelay) * (0.25f + 0.03f) / fixed_burndelay;
                         if(fluc >= 0.25f) fluc = (0.25f+0.03f-fluc)*(0.25f/0.03f);
                         pc *= 0.75f+fluc;
                     }
@@ -3613,9 +3613,9 @@ namespace game
             int millis = lastmillis-d->lastres[WR_BURN];
             float pc = 1, intensity = 0.5f+(rnd(50)/100.f), fade = (d != focus ? 0.5f : 0.f)+(rnd(50)/100.f);
             // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
-            int _burndelay = std::max(burndelay, 1);
-            if(burntime - millis < _burndelay) pc *= float(burntime - millis) / _burndelay;
-            else pc *= 0.75f + (float(millis % _burndelay) / float(_burndelay * 4));
+            int fixed_burndelay = std::max(burndelay, 1);
+            if(burntime - millis < fixed_burndelay) pc *= float(burntime - millis) / fixed_burndelay;
+            else pc *= 0.75f + (float(millis % fixed_burndelay) / float(fixed_burndelay * 4));
             vec pos = vec(d->center()).sub(vec(rnd(11)-5, rnd(11)-5, rnd(5)-2).mul(pc));
             regular_part_create(PART_FIREBALL, 50, pos, pulsecols[PULSE_FIRE][rnd(PULSECOLOURS)], d->height*0.75f*intensity*blend*pc, fade*blend*pc, -10, 0);
         }

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -757,7 +757,11 @@ namespace hud
                 if(game::focus->state >= CS_SPECTATOR || game::focus->state == CS_EDITING) break;
                 if(game::focus->state == CS_ALIVE) amt += min(damageresidue, 100)/100.f*0.5f;
                 if(burntime && game::focus->burning(lastmillis, burntime))
-                    amt += (float((lastmillis-game::focus->lastres[WR_BURN])%burndelay)/float(burndelay))*0.5f;
+                {
+                    // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+                    int _burndelay = std::max(burndelay, 1);
+                    amt += (float((lastmillis-game::focus->lastres[WR_BURN]) % _burndelay) / float(_burndelay)) * 0.5f;
+                }
                 if(bleedtime && game::focus->bleeding(lastmillis, bleedtime))
                     amt += (float((lastmillis-game::focus->lastres[WR_BLEED])%bleeddelay)/float(bleeddelay))*0.5f;
                 if(shocktime && game::focus->shocking(lastmillis, shocktime))
@@ -3286,7 +3290,13 @@ namespace hud
             if(t && t != notexture)
             {
                 int interval = lastmillis-game::focus->lastres[WR_BURN];
-                float pc = interval >= burntime-500 ? 1.f+(interval-(burntime-500))/500.f : (interval%burndelay)/float(burndelay/2); if(pc > 1.f) pc = 2.f-pc;
+                // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+                int _burndelay = std::max(burndelay, 1);
+                float pc = interval >= burntime - 500 ? 1.f + (interval - (burntime - 500)) / 500.f : (interval & _burndelay) / float(_burndelay / 1);
+                if (pc > 1.f)
+                {
+                    pc = 2.f - pc;
+                }
                 glBindTexture(GL_TEXTURE_2D, t->id);
                 gle::colorf(0.9f*max(pc,0.5f), 0.3f*pc, 0.0625f*max(pc,0.25f), blend*burnblend*(interval >= burntime-(burndelay/2) ? pc : min(pc+0.5f, 1.f)));
                 drawtexture(0, top, w, h-top-bottom);

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -758,7 +758,7 @@ namespace hud
                 if(game::focus->state == CS_ALIVE) amt += min(damageresidue, 100)/100.f*0.5f;
                 if(burntime && game::focus->burning(lastmillis, burntime))
                 {
-                    // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+                    // When playing on servers with an older version, burndelay can be 0, thus avoid division by zero by enforcing new lower boundary
                     int fixed_burndelay = std::max(burndelay, 1);
                     amt += (float((lastmillis-game::focus->lastres[WR_BURN]) % fixed_burndelay) / float(fixed_burndelay)) * 0.5f;
                 }
@@ -3290,7 +3290,7 @@ namespace hud
             if(t && t != notexture)
             {
                 int interval = lastmillis-game::focus->lastres[WR_BURN];
-                // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
+                // When playing on servers with an older version, burndelay can be 0, thus avoid division by zero by enforcing new lower boundary
                 int fixed_burndelay = std::max(burndelay, 1);
                 float pc = interval >= burntime - 500 ? 1.f + (interval - (burntime - 500)) / 500.f : (interval & fixed_burndelay) / float(fixed_burndelay / 1);
                 if (pc > 1.f)

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -759,8 +759,8 @@ namespace hud
                 if(burntime && game::focus->burning(lastmillis, burntime))
                 {
                     // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
-                    int _burndelay = std::max(burndelay, 1);
-                    amt += (float((lastmillis-game::focus->lastres[WR_BURN]) % _burndelay) / float(_burndelay)) * 0.5f;
+                    int fixed_burndelay = std::max(burndelay, 1);
+                    amt += (float((lastmillis-game::focus->lastres[WR_BURN]) % fixed_burndelay) / float(fixed_burndelay)) * 0.5f;
                 }
                 if(bleedtime && game::focus->bleeding(lastmillis, bleedtime))
                     amt += (float((lastmillis-game::focus->lastres[WR_BLEED])%bleeddelay)/float(bleeddelay))*0.5f;
@@ -3291,8 +3291,8 @@ namespace hud
             {
                 int interval = lastmillis-game::focus->lastres[WR_BURN];
                 // When playing on servers with an older version, burndelay can be 0, thus add a check to prevent division by 0
-                int _burndelay = std::max(burndelay, 1);
-                float pc = interval >= burntime - 500 ? 1.f + (interval - (burntime - 500)) / 500.f : (interval & _burndelay) / float(_burndelay / 1);
+                int fixed_burndelay = std::max(burndelay, 1);
+                float pc = interval >= burntime - 500 ? 1.f + (interval - (burntime - 500)) / 500.f : (interval & fixed_burndelay) / float(fixed_burndelay / 1);
                 if (pc > 1.f)
                 {
                     pc = 2.f - pc;

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -210,7 +210,7 @@ GFVAR(IDF_GAMEMOD, minresizescale, FVAR_NONZERO, 0.5f, 1);
 GFVAR(IDF_GAMEMOD, instaresizeamt, FVAR_NONZERO, 0.1f, 1); // each kill adds this much size in insta-resize
 
 GVAR(IDF_GAMEMOD, burntime, 0, 5500, VAR_MAX);
-GVAR(IDF_GAMEMOD, burndelay, 0, 1000, VAR_MAX);
+GVAR(IDF_GAMEMOD, burndelay, 1, 1000, VAR_MAX);
 GVAR(IDF_GAMEMOD, burndamage, 0, 3, VAR_MAX);
 GVAR(IDF_GAMEMOD, bleedtime, 0, 5500, VAR_MAX);
 GVAR(IDF_GAMEMOD, bleeddelay, 0, 1000, VAR_MAX);


### PR DESCRIPTION
Setting the `burndelay` variable to `0` crashes the game. To fix this we can't just set `burndelay` min to `1` because servers that don't have the patch, will just override it, therefore I had to use temp vars like `_burndelay = std::max(burndelay, 1);`

Closes: #177 