### PR TITLE
Fix game crash when shockdelay is 0 bug

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -949,12 +949,20 @@ namespace game
                     int millis = lastmillis-d->lastres[WR_SHOCK];
                     size_t seed = size_t(d) + (millis/50);
                     float pc = 1, amt = (millis%50)/50.0f, intensity = 0.75f+(detrnd(seed, 25)*(1-amt) + detrnd(seed + 1, 25)*amt)/100.f;
-                    if(shocktime-millis < shockdelay) pc *= float(shocktime-millis)/float(shockdelay);
+                    // When playing on servers with an older version, shockdelay can be 0, thus add a check to prevent division by 0
+                    int _shockdelay = std::max(shockdelay, 1);
+                    if(shocktime - millis < _shockdelay)
+                    {
+                        pc *= float(shocktime - millis) / float(_shockdelay);
+                    }
                     else
                     {
-                        float fluc = float(millis%shockdelay)*(0.25f+0.03f)/shockdelay;
-                        if(fluc >= 0.25f) fluc = (0.25f+0.03f-fluc)*(0.25f/0.03f);
-                        pc *= 0.75f+fluc;
+                        float fluc = float(millis % _shockdelay) * (0.25f + 0.03f) / _shockdelay;
+                        if (fluc >= 0.25f) 
+                        {
+                            fluc = (0.25f + 0.03f - fluc) * (0.25f / 0.03f);
+                        }
+                        pc *= 0.75f + fluc;
                     }
                     adddynlight(d->center(), d->height*intensity*pc, rescolour(d, PULSE_SHOCK).mul(pc), 0, 0, DL_KEEP);
                 }

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -760,8 +760,12 @@ namespace hud
                     amt += (float((lastmillis-game::focus->lastres[WR_BURN])%burndelay)/float(burndelay))*0.5f;
                 if(bleedtime && game::focus->bleeding(lastmillis, bleedtime))
                     amt += (float((lastmillis-game::focus->lastres[WR_BLEED])%bleeddelay)/float(bleeddelay))*0.5f;
-                if(shocktime && game::focus->shocking(lastmillis, shocktime))
-                    amt += (float((lastmillis-game::focus->lastres[WR_SHOCK])%shockdelay)/float(shockdelay))*0.5f;
+                if (shocktime && game::focus->shocking(lastmillis, shocktime))
+                {
+                    // When playing on servers with an older version, shockdelay can be 0, thus add a check to prevent division by 0
+                    int _shockdelay = std::max(shockdelay, 1);
+                    amt += (float((lastmillis - game::focus->lastres[WR_SHOCK]) % _shockdelay) / float(_shockdelay)) * 0.5f;
+                }
                 break;
             }
             case 2: amt = motionbluramt; break;

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -216,7 +216,7 @@ GVAR(IDF_GAMEMOD, bleedtime, 0, 5500, VAR_MAX);
 GVAR(IDF_GAMEMOD, bleeddelay, 0, 1000, VAR_MAX);
 GVAR(IDF_GAMEMOD, bleeddamage, 0, 3, VAR_MAX);
 GVAR(IDF_GAMEMOD, shocktime, 0, 5500, VAR_MAX);
-GVAR(IDF_GAMEMOD, shockdelay, 0, 1000, VAR_MAX);
+GVAR(IDF_GAMEMOD, shockdelay, 1, 1000, VAR_MAX);
 GVAR(IDF_GAMEMOD, shockdamage, 0, 2, VAR_MAX);
 GVAR(IDF_GAMEMOD, shockstun, 0, W_N_ST, W_N_ALL);
 GFVAR(IDF_GAMEMOD, shockstunscale, 0, 0.5f, FVAR_MAX);


### PR DESCRIPTION
This PR is basically the same as #179 but for the variable `shockdelay`