### PR TITLE
Don't construct the string outside of vector

### DIFF
--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -2767,7 +2767,7 @@ void explodelist(const char *s, std::vector<std::string> &elems, int limit)
 {
     const char *start, *end;
     while((limit < 0 || elems.size() < limit) && parselist(s, start, end))
-        elems.emplace_back(std::string(start, end-start));
+        elems.emplace_back(start, end - start);
 }
 
 char *indexlist(const char *s, int pos)


### PR DESCRIPTION
This code caused the string to be constructed and then moved into the
vector.  With this change the string in constructed inside the vector.