### PR TITLE
Use std::abs() and std::fabs() instead of abs() and fabs()

### DIFF
--- a/src/engine/animmodel.h
+++ b/src/engine/animmodel.h
@@ -162,7 +162,7 @@ struct animmodel : model
             {
                 float curpulse = lastmillis*glowpulse;
                 curpulse -= floor(curpulse);
-                curglow += glowdelta*2*fabs(curpulse - 0.5f);
+                curglow += glowdelta*2*std::fabs(curpulse - 0.5f);
             }
             if(material <= 0 || !lightmaterial) LOCALPARAMF(lightmaterial, 2, 2, 2);
             if(material2 <= 0 || !lightmaterial) LOCALPARAMF(lightmaterial2, 2, 2, 2);

--- a/src/engine/bih.h
+++ b/src/engine/bih.h
@@ -23,9 +23,9 @@ struct BIH
 
         bool outside(const ivec &bo, const ivec &br) const
         {
-            return abs(bo.x - center.x) > br.x + radius.x ||
-                   abs(bo.y - center.y) > br.y + radius.y ||
-                   abs(bo.z - center.z) > br.z + radius.z;
+            return std::abs(bo.x - center.x) > br.x + radius.x ||
+                   std::abs(bo.y - center.y) > br.y + radius.y ||
+                   std::abs(bo.z - center.z) > br.z + radius.z;
         }
     };
 

--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -3303,8 +3303,8 @@ ICOMMAND(0, maxf, "V", (tagval *args, int numargs),
     loopi(numargs - 1) val = max(val, args[i].getfloat());
     floatret(val);
 });
-ICOMMAND(0, abs, "i", (int *n), intret(abs(*n)));
-ICOMMAND(0, absf, "f", (float *n), floatret(fabs(*n)));
+ICOMMAND(0, abs, "i", (int *n), intret(std::abs(*n)));
+ICOMMAND(0, absf, "f", (float *n), floatret(std::fabs(*n)));
 ICOMMAND(0, precf, "fi", (float *a, int *b),
 {
     defformatstring(format, "%%.%df", max(*b, 0));

--- a/src/engine/decal.cpp
+++ b/src/engine/decal.cpp
@@ -443,12 +443,12 @@ struct decalrenderer
 #if 0
             // intersect ray along decal normal with plane
             float dist = n.dot(p) / facing;
-            if(fabs(dist) > decalradius) continue;
+            if(std::fabs(dist) > decalradius) continue;
             vec pcenter = vec(decalnormal).mul(dist).add(decalcenter);
 #else
             // travel back along plane normal from the decal center
             float dist = n.dot(p);
-            if(fabs(dist) > decalradius) continue;
+            if(std::fabs(dist) > decalradius) continue;
             vec pcenter = vec(n).mul(dist).add(decalcenter);
 #endif
             vec ft, fb;

--- a/src/engine/material.cpp
+++ b/src/engine/material.cpp
@@ -491,10 +491,10 @@ static inline bool vismatcmp(const materialsurface *xm, const materialsurface *y
         int c = sortorigin[dim];
         if(c > xmin && c < xmax) return sortedit;
         if(c > ymin && c < ymax) return !sortedit;
-        xmin = abs(xmin - c);
-        xmax = abs(xmax - c);
-        ymin = abs(ymin - c);
-        ymax = abs(ymax - c);
+        xmin = std::abs(xmin - c);
+        xmax = std::abs(xmax - c);
+        ymin = std::abs(ymin - c);
+        ymax = std::abs(ymax - c);
         if(max(xmin, xmax) <= min(ymin, ymax)) return sortedit;
         else if(max(ymin, ymax) <= min(xmin, xmax)) return !sortedit;
     }
@@ -508,7 +508,7 @@ void sortmaterials(vector<materialsurface *> &vismats)
     sortorigin = ivec(camera1->o);
     if(reflecting) sortorigin.z = int(reflectz - (camera1->o.z - reflectz));
     vec dir(camera1->yaw*RAD, reflecting ? -camera1->pitch : camera1->pitch);
-    loopi(3) { dir[i] = fabs(dir[i]); sortdim[i] = i; }
+    loopi(3) { dir[i] = std::fabs(dir[i]); sortdim[i] = i; }
     if(dir[sortdim[2]] > dir[sortdim[1]]) std::swap(sortdim[2], sortdim[1]);
     if(dir[sortdim[1]] > dir[sortdim[0]]) std::swap(sortdim[1], sortdim[0]);
     if(dir[sortdim[2]] > dir[sortdim[1]]) std::swap(sortdim[2], sortdim[1]);
@@ -704,7 +704,7 @@ void rendermaterials()
                         glBindTexture(GL_TEXTURE_2D, mslot->sts[1].t->id);
                         float angle = fmod(float(lastmillis/600.0f/(2*M_PI)), 1.0f),
                               s = angle - int(angle) - 0.5f;
-                        s *= 8 - fabs(s)*16;
+                        s *= 8 - std::fabs(s)*16;
                         wfwave = vertwater ? WATER_AMPLITUDE*s-WATER_OFFSET : -WATER_OFFSET;
                         wfscroll = 16.0f*lastmillis/1000.0f;
                         wfxscale = TEX_SCALE/(mslot->sts[1].t->xs*mslot->scale);
@@ -802,7 +802,7 @@ void rendermaterials()
                     {
                         float angle = fmod(float(lastmillis/2000.0f/(2*M_PI)), 1.0f),
                               s = angle - int(angle) - 0.5f;
-                        s *= 8 - fabs(s)*16;
+                        s *= 8 - std::fabs(s)*16;
                         wfwave = vertwater ? WATER_AMPLITUDE*s-WATER_OFFSET : -WATER_OFFSET;
                         wfscroll = 16.0f*lastmillis/3000.0f;
                         wfxscale = TEX_SCALE/(mslot->sts[1].t->xs*mslot->scale);
@@ -814,7 +814,7 @@ void rendermaterials()
                         if(blended) { glDisable(GL_BLEND); blended = false; }
                         float t = lastmillis/2000.0f;
                         t -= floor(t);
-                        t = 1.0f - 2*fabs(t-0.5f);
+                        t = 1.0f - 2*std::fabs(t-0.5f);
                         extern int glare;
                         if(glare) t = 0.625f + 0.075f*t;
                         else t = 0.5f + 0.5f*t;

--- a/src/engine/mpr.h
+++ b/src/engine/mpr.h
@@ -68,7 +68,7 @@ namespace mpr
         {
             vec n = orient.transform(wn).div(vec(ent->xradius, ent->yradius, (ent->aboveeye + ent->height)/2)),
                 dir = orient.transform(wdir),
-                an(fabs(n.x), fabs(n.y), dir.z ? fabs(n.z) : 0),
+                an(std::fabs(n.x), std::fabs(n.y), dir.z ? std::fabs(n.z) : 0),
                 fn(0, 0, 0);
             if(an.x > an.y)
             {
@@ -208,7 +208,7 @@ namespace mpr
         vec contactface(const vec &wn, const vec &wdir) const
         {
             vec n = orient.transform(wn).div(radius), dir = orient.transform(wdir),
-                an(fabs(n.x), fabs(n.y), dir.z ? fabs(n.z) : 0),
+                an(std::fabs(n.x), std::fabs(n.y), dir.z ? std::fabs(n.z) : 0),
                 fn(0, 0, 0);
             if(an.x > an.y)
             {

--- a/src/engine/normal.cpp
+++ b/src/engine/normal.cpp
@@ -207,7 +207,7 @@ void addnormals(cube &c, const ivec &o, int size)
             int edge = tjoints[tj].edge, e1 = edge%(MAXFACEVERTS+1), e2 = (e1+1)%numverts;
             const vec &v1 = pos[e1], &v2 = pos[e2];
             ivec d(vec(v2).sub(v1).mul(8));
-            int axis = abs(d.x) > abs(d.y) ? (abs(d.x) > abs(d.z) ? 0 : 2) : (abs(d.y) > abs(d.z) ? 1 : 2);
+            int axis = std::abs(d.x) > std::abs(d.y) ? (std::abs(d.x) > std::abs(d.z) ? 0 : 2) : (std::abs(d.y) > std::abs(d.z) ? 1 : 2);
             if(d[axis] < 0) d.neg();
             reduceslope(d);
             int origin = int(min(v1[axis], v2[axis])*8)&~0x7FFF,

--- a/src/engine/octa.cpp
+++ b/src/engine/octa.cpp
@@ -222,7 +222,7 @@ cube &lookupcube(const ivec &to, int tsize, ivec &ro, int &rsize)
     int tx = clamp(to.x, 0, hdr.worldsize-1),
         ty = clamp(to.y, 0, hdr.worldsize-1),
         tz = clamp(to.z, 0, hdr.worldsize-1);
-    int scale = worldscale-1, csize = abs(tsize);
+    int scale = worldscale-1, csize = std::abs(tsize);
     cube *c = &worldroot[octastep(tx, ty, tz, scale)];
     if(!(csize>>scale)) do
     {
@@ -348,7 +348,7 @@ static int midedge(const ivec &a, const ivec &b, int xd, int yd, bool &perfect)
     int risex = (by-ay)*(8-ax)*256;
     int s = risex/(bx-ax);
     int y = s/256 + ay;
-    if(((abs(s)&0xFF)!=0) || // ie: rounding error
+    if(((std::abs(s)&0xFF)!=0) || // ie: rounding error
         (crossy && y!=8) ||
         (y<0 || y>16)) perfect = false;
     return crossy ? 8 : min(max(y, 0), 16);

--- a/src/engine/octaedit.cpp
+++ b/src/engine/octaedit.cpp
@@ -286,9 +286,9 @@ void updateselection()
     sel.o.x = min(lastcur.x, cur.x);
     sel.o.y = min(lastcur.y, cur.y);
     sel.o.z = min(lastcur.z, cur.z);
-    sel.s.x = abs(lastcur.x-cur.x)/sel.grid+1;
-    sel.s.y = abs(lastcur.y-cur.y)/sel.grid+1;
-    sel.s.z = abs(lastcur.z-cur.z)/sel.grid+1;
+    sel.s.x = std::abs(lastcur.x-cur.x)/sel.grid+1;
+    sel.s.y = std::abs(lastcur.y-cur.y)/sel.grid+1;
+    sel.s.z = std::abs(lastcur.z-cur.z)/sel.grid+1;
 }
 
 bool editmoveplane(const vec &o, const vec &ray, int d, float off, vec &handle, vec &dest, bool first)

--- a/src/engine/octarender.cpp
+++ b/src/engine/octarender.cpp
@@ -551,7 +551,7 @@ void reduceslope(ivec &n)
     int mindim = -1, minval = 64;
     loopi(3) if(n[i])
     {
-        int val = abs(n[i]);
+        int val = std::abs(n[i]);
         if(mindim < 0 || val < minval)
         {
             mindim = i;
@@ -629,7 +629,7 @@ void addtris(const sortkey &key, int orient, vertex *verts, int *index, int numv
                 int e1 = cedge%(MAXFACEVERTS+1), e2 = (e1+1)%numverts;
                 vertex &v1 = verts[e1], &v2 = verts[e2];
                 ivec d(vec(v2.pos).sub(v1.pos).mul(8));
-                int axis = abs(d.x) > abs(d.y) ? (abs(d.x) > abs(d.z) ? 0 : 2) : (abs(d.y) > abs(d.z) ? 1 : 2);
+                int axis = std::abs(d.x) > std::abs(d.y) ? (std::abs(d.x) > std::abs(d.z) ? 0 : 2) : (std::abs(d.y) > std::abs(d.z) ? 1 : 2);
                 if(d[axis] < 0) d.neg();
                 reduceslope(d);
                 int origin = int(min(v1.pos[axis], v2.pos[axis])*8)&~0x7FFF,
@@ -704,9 +704,9 @@ void addgrasstri(int face, vertex *verts, int numv, ushort texture, ushort lmid)
     float scale;
     int px, py;
 
-    if(fabs(area.x) >= fabs(area.y) && fabs(area.x) >= fabs(area.z))
+    if(std::fabs(area.x) >= std::fabs(area.y) && std::fabs(area.x) >= std::fabs(area.z))
         scale = 1/area.x, px = 1, py = 2;
-    else if(fabs(area.y) >= fabs(area.x) && fabs(area.y) >= fabs(area.z))
+    else if(std::fabs(area.y) >= std::fabs(area.x) && std::fabs(area.y) >= std::fabs(area.z))
         scale = -1/area.y, px = 0, py = 2;
     else
         scale = 1/area.z, px = 0, py = 1;
@@ -957,7 +957,7 @@ void gencubeedges(cube &c, const ivec &co, int size)
             ivec d = pos[e2];
             d.sub(pos[e1]);
             if(d.iszero()) continue;
-            int axis = abs(d.x) > abs(d.y) ? (abs(d.x) > abs(d.z) ? 0 : 2) : (abs(d.y) > abs(d.z) ? 1 : 2);
+            int axis = std::abs(d.x) > std::abs(d.y) ? (std::abs(d.x) > std::abs(d.z) ? 0 : 2) : (std::abs(d.y) > std::abs(d.z) ? 1 : 2);
             if(d[axis] < 0)
             {
                 d.neg();

--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -82,7 +82,7 @@ bool pointincube(const clipplanes &p, const vec &v)
     { \
         if(ray[i]) \
         { \
-            float prad = fabs(p.r[i] * invray[i]), pdist = (p.o[i] - v[i]) * invray[i], pmin = pdist - prad, pmax = pdist + prad; \
+            float prad = std::fabs(p.r[i] * invray[i]), pdist = (p.o[i] - v[i]) * invray[i], pmin = pdist - prad, pmax = pdist + prad; \
             if(pmin > enterdist) \
             { \
                 if(pmin > exitdist) exit; \
@@ -760,7 +760,7 @@ static bool fuzzycollidebox(physent *d, const vec &dir, float cutoff, const vec 
     mpr::ModelOBB mdlvol(o, center, radius, yaw, pitch, roll);
     vec bbradius = mdlvol.orient.abstransposedtransform(radius);
 
-    if(fabs(d->o.x - mdlvol.o.x) > bbradius.x + d->radius || fabs(d->o.y - mdlvol.o.y) > bbradius.y + d->radius ||
+    if(std::fabs(d->o.x - mdlvol.o.x) > bbradius.x + d->radius || std::fabs(d->o.y - mdlvol.o.y) > bbradius.y + d->radius ||
        d->o.z + d->aboveeye < mdlvol.o.z - bbradius.z || d->o.z - d->height > mdlvol.o.z + bbradius.z)
         return false;
 
@@ -812,7 +812,7 @@ static bool fuzzycollideellipse(physent *d, const vec &dir, float cutoff, const 
     mpr::ModelEllipse mdlvol(o, center, radius, yaw, pitch, roll);
     vec bbradius = mdlvol.orient.abstransposedtransform(radius);
 
-    if(fabs(d->o.x - mdlvol.o.x) > bbradius.x + d->radius || fabs(d->o.y - mdlvol.o.y) > bbradius.y + d->radius ||
+    if(std::fabs(d->o.x - mdlvol.o.x) > bbradius.x + d->radius || std::fabs(d->o.y - mdlvol.o.y) > bbradius.y + d->radius ||
        d->o.z + d->aboveeye < mdlvol.o.z - bbradius.z || d->o.z - d->height > mdlvol.o.z + bbradius.z)
         return false;
 
@@ -917,7 +917,7 @@ template<class E>
 static bool fuzzycollidesolid(physent *d, const vec &dir, float cutoff, const cube &c, const ivec &co, int size) // collide with solid cube geometry
 {
     int crad = size/2;
-    if(fabs(d->o.x - co.x - crad) > d->radius + crad || fabs(d->o.y - co.y - crad) > d->radius + crad ||
+    if(std::fabs(d->o.x - co.x - crad) > d->radius + crad || std::fabs(d->o.y - co.y - crad) > d->radius + crad ||
        d->o.z + d->aboveeye < co.z || d->o.z - d->height > co.z + size)
         return false;
 
@@ -956,21 +956,21 @@ static bool fuzzycollidesolid(physent *d, const vec &dir, float cutoff, const cu
 template<class E>
 static inline bool clampcollide(const clipplanes &p, const E &entvol, const plane &w, const vec &pw)
 {
-    if(w.x && (w.y || w.z) && fabs(pw.x - p.o.x) > p.r.x)
+    if(w.x && (w.y || w.z) && std::fabs(pw.x - p.o.x) > p.r.x)
     {
         vec c = entvol.center();
         float fv = pw.x < p.o.x ? p.o.x-p.r.x : p.o.x+p.r.x, fdist = (w.x*fv + w.y*c.y + w.z*c.z + w.offset) / (w.y*w.y + w.z*w.z);
         vec fdir(fv - c.x, -w.y*fdist, -w.z*fdist);
         if((pw.y-c.y-fdir.y)*w.y + (pw.z-c.z-fdir.z)*w.z >= 0 && entvol.supportpoint(fdir).squaredist(c) < fdir.squaredlen()) return true;
     }
-    if(w.y && (w.x || w.z) && fabs(pw.y - p.o.y) > p.r.y)
+    if(w.y && (w.x || w.z) && std::fabs(pw.y - p.o.y) > p.r.y)
     {
         vec c = entvol.center();
         float fv = pw.y < p.o.y ? p.o.y-p.r.y : p.o.y+p.r.y, fdist = (w.x*c.x + w.y*fv + w.z*c.z + w.offset) / (w.x*w.x + w.z*w.z);
         vec fdir(-w.x*fdist, fv - c.y, -w.z*fdist);
         if((pw.x-c.x-fdir.x)*w.x + (pw.z-c.z-fdir.z)*w.z >= 0 && entvol.supportpoint(fdir).squaredist(c) < fdir.squaredlen()) return true;
     }
-    if(w.z && (w.x || w.y) && fabs(pw.z - p.o.z) > p.r.z)
+    if(w.z && (w.x || w.y) && std::fabs(pw.z - p.o.z) > p.r.z)
     {
         vec c = entvol.center();
         float fv = pw.z < p.o.z ? p.o.z-p.r.z : p.o.z+p.r.z, fdist = (w.x*c.x + w.y*c.y + w.z*fv + w.offset) / (w.x*w.x + w.y*w.y);
@@ -985,7 +985,7 @@ static bool fuzzycollideplanes(physent *d, const vec &dir, float cutoff, const c
 {
     const clipplanes &p = getclipplanes(c, co, size);
 
-    if(fabs(d->o.x - p.o.x) > p.r.x + d->radius || fabs(d->o.y - p.o.y) > p.r.y + d->radius ||
+    if(std::fabs(d->o.x - p.o.x) > p.r.x + d->radius || std::fabs(d->o.y - p.o.y) > p.r.y + d->radius ||
        d->o.z + d->aboveeye < p.o.z - p.r.z || d->o.z - d->height > p.o.z + p.r.z)
         return false;
 
@@ -1035,7 +1035,7 @@ template<class E>
 static bool cubecollidesolid(physent *d, const vec &dir, float cutoff, const cube &c, const ivec &co, int size) // collide with solid cube geometry
 {
     int crad = size/2;
-    if(fabs(d->o.x - co.x - crad) > d->radius + crad || fabs(d->o.y - co.y - crad) > d->radius + crad ||
+    if(std::fabs(d->o.x - co.x - crad) > d->radius + crad || std::fabs(d->o.y - co.y - crad) > d->radius + crad ||
        d->o.z + d->aboveeye < co.z || d->o.z - d->height > co.z + size)
         return false;
 
@@ -1066,7 +1066,7 @@ static bool cubecollideplanes(physent *d, const vec &dir, float cutoff, const cu
 {
     const clipplanes &p = getclipplanes(c, co, size);
 
-    if(fabs(d->o.x - p.o.x) > p.r.x + d->radius || fabs(d->o.y - p.o.y) > p.r.y + d->radius ||
+    if(std::fabs(d->o.x - p.o.x) > p.r.x + d->radius || std::fabs(d->o.y - p.o.y) > p.r.y + d->radius ||
        d->o.z + d->aboveeye < p.o.z - p.r.z || d->o.z - d->height > p.o.z + p.r.z)
         return false;
 
@@ -1267,8 +1267,8 @@ bool getsight(vec &o, float yaw, float pitch, vec &q, vec &v, float mdist, float
 
     if(dist <= mdist)
     {
-        float x = fmod(fabs(asin((q.z-o.z)/dist)/RAD-pitch), 360);
-        float y = fmod(fabs(-atan2(q.x-o.x, q.y-o.y)/RAD-yaw), 360);
+        float x = fmod(std::fabs(asin((q.z-o.z)/dist)/RAD-pitch), 360);
+        float y = fmod(std::fabs(-atan2(q.x-o.x, q.y-o.y)/RAD-yaw), 360);
         if(min(x, 360-x) <= fovx && min(y, 360-y) <= fovy) return raycubelos(o, q, v);
     }
     return false;

--- a/src/engine/ragdoll.h
+++ b/src/engine/ragdoll.h
@@ -334,7 +334,7 @@ void ragdolldata::constrainrot()
         vec axis;
         float angle;
         if(!rot.calcangleaxis(angle, axis)) continue;
-        angle = r.maxangle - fabs(angle);
+        angle = r.maxangle - std::fabs(angle);
         if(angle >= 0) continue;
         angle += 1e-3f;
 
@@ -366,7 +366,7 @@ void ragdolldata::applyrotfriction(float ts)
         float angle;
         if(rot.calcangleaxis(angle, axis))
         {
-            angle *= -(fabs(angle) >= stopangle ? rotfric : 1.0f);
+            angle *= -(std::fabs(angle) >= stopangle ? rotfric : 1.0f);
             applyrotlimit(skel->tris[r.tri[0]], skel->tris[r.tri[1]], angle, axis);
         }
     }

--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -942,7 +942,7 @@ static LocalShaderParam screentexcoord[2] = { LocalShaderParam("screentexcoord0"
 
 static inline void setscreentexcoord(int i, float w, float h, float x = 0, float y = 0)
 {
-    screentexcoord[i].setf(w*0.5f, h*0.5f, x + w*0.5f, y + fabs(h)*0.5f);
+    screentexcoord[i].setf(w*0.5f, h*0.5f, x + w*0.5f, y + std::fabs(h)*0.5f);
 }
 
 void screenquad(float sw, float sh)
@@ -1354,7 +1354,7 @@ void drawreflection(float z, bool refract, int fogdepth, const bvec &col)
 
     if(fading)
     {
-        float scale = fogging ? -0.25f : 0.25f, offset = 2*fabs(scale) - scale*z;
+        float scale = fogging ? -0.25f : 0.25f, offset = 2*std::fabs(scale) - scale*z;
         GLOBALPARAMF(waterfadeparams, scale, offset, -scale, offset + camera1->o.z*scale);
     }
 

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -746,9 +746,9 @@ static inline void enablecullmodelquery()
 
 static inline void rendercullmodelquery(model *m, dynent *d, const vec &center, float radius)
 {
-    if(fabs(camera1->o.x-center.x) < radius+1 &&
-       fabs(camera1->o.y-center.y) < radius+1 &&
-       fabs(camera1->o.z-center.z) < radius+1)
+    if(std::fabs(camera1->o.x-center.x) < radius+1 &&
+       std::fabs(camera1->o.y-center.y) < radius+1 &&
+       std::fabs(camera1->o.z-center.z) < radius+1)
     {
         d->query = NULL;
         return;
@@ -1113,8 +1113,8 @@ void setbbfrommodel(dynent *d, const char *mdl, float size)
     m->collisionbox(center, radius);
     if(d->type==ENT_INANIMATE && !m->ellipsecollide)
         d->collidetype = COLLIDE_OBB;
-    d->xradius  = (radius.x + fabs(center.x))*size;
-    d->yradius  = (radius.y + fabs(center.y))*size;
+    d->xradius  = (radius.x + std::fabs(center.x))*size;
+    d->yradius  = (radius.y + std::fabs(center.y))*size;
     d->radius   = d->collidetype==COLLIDE_OBB ? sqrtf(d->xradius*d->xradius + d->yradius*d->yradius) : max(d->xradius, d->yradius);
     d->height   = (d->zradius = (center.z-radius.z) + radius.z*2*m->height)*size;
     d->aboveeye = radius.z*2*(1.0f-m->height);

--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -443,7 +443,7 @@ uint getclientip(int n)         { int o = server::peerowner(n); return clients.i
 
 void sendpacket(int n, int chan, ENetPacket *packet, int exclude)
 {
-    if(n < 0 || chan < 0) server::recordpacket(abs(chan), packet->data, packet->dataLength);
+    if(n < 0 || chan < 0) server::recordpacket(std::abs(chan), packet->data, packet->dataLength);
     if(chan < 0) return; // was just a record packet
     if(n < 0)
     {

--- a/src/engine/skelmodel.h
+++ b/src/engine/skelmodel.h
@@ -573,7 +573,7 @@ struct skelmodel : animmodel
             {
                 int bone = schedule[i];
                 const boneinfo &info = bones[bone];
-                loopj(numbones) if(abs(bones[j].group) == bone && bones[j].scheduled < 0)
+                loopj(numbones) if(std::abs(bones[j].group) == bone && bones[j].scheduled < 0)
                 {
                     antipodes.add(antipode(info.interpindex, bones[j].interpindex));
                     bones[j].scheduled = schedule.length();
@@ -582,7 +582,7 @@ struct skelmodel : animmodel
                 if(i + 1 == schedule.length())
                 {
                     int conflict = INT_MAX;
-                    loopj(numbones) if(bones[j].group < numbones && bones[j].scheduled < 0) conflict = min(conflict, abs(bones[j].group));
+                    loopj(numbones) if(bones[j].group < numbones && bones[j].scheduled < 0) conflict = min(conflict, std::abs(bones[j].group));
                     if(conflict < numbones)
                     {
                         bones[conflict].scheduled = schedule.length();
@@ -1700,8 +1700,8 @@ template<class MDL> struct skelcommands : modelcommands<MDL, struct MDL::skelmes
                 }
                 else
                 {
-                    b.pitchmin = -360*fabs(b.pitchscale) + b.pitchoffset;
-                    b.pitchmax = 360*fabs(b.pitchscale) + b.pitchoffset;
+                    b.pitchmin = -360*std::fabsf(b.pitchscale) + b.pitchoffset;
+                    b.pitchmax = 360*std::fabsf(b.pitchscale) + b.pitchoffset;
                 }
                 return;
             }
@@ -1718,8 +1718,8 @@ template<class MDL> struct skelcommands : modelcommands<MDL, struct MDL::skelmes
         }
         else
         {
-            mdl.pitchmin = -360*fabs(mdl.pitchscale) + mdl.pitchoffset;
-            mdl.pitchmax = 360*fabs(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmin = -360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmax = 360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
         }
     }
 

--- a/src/engine/skelmodel.h
+++ b/src/engine/skelmodel.h
@@ -1700,8 +1700,8 @@ template<class MDL> struct skelcommands : modelcommands<MDL, struct MDL::skelmes
                 }
                 else
                 {
-                    b.pitchmin = -360*std::fabsf(b.pitchscale) + b.pitchoffset;
-                    b.pitchmax = 360*std::fabsf(b.pitchscale) + b.pitchoffset;
+                    b.pitchmin = -360*std::fabs(b.pitchscale) + b.pitchoffset;
+                    b.pitchmax = 360*std::fabs(b.pitchscale) + b.pitchoffset;
                 }
                 return;
             }
@@ -1718,8 +1718,8 @@ template<class MDL> struct skelcommands : modelcommands<MDL, struct MDL::skelmes
         }
         else
         {
-            mdl.pitchmin = -360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
-            mdl.pitchmax = 360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmin = -360*std::fabs(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmax = 360*std::fabs(mdl.pitchscale) + mdl.pitchoffset;
         }
     }
 

--- a/src/engine/ui.cpp
+++ b/src/engine/ui.cpp
@@ -654,7 +654,7 @@ struct gui : guient
             e->linewrap = (length < 0);
             e->maxx = e->linewrap ? -1 : length;
             e->maxy = (height <= 0) ? 1 : -1;
-            e->pixelwidth = (abs(length)+1)*FONTW;
+            e->pixelwidth = (std::abs(length)+1)*FONTW;
             if(e->linewrap && e->maxy == 1)
             {
                 int temp = 0;
@@ -1225,7 +1225,7 @@ struct gui : guient
             {
                 hitx = (cursorx - uiorigin.x)/uiscale.x;
                 hity = (cursory - uiorigin.y)/uiscale.y;
-                if((mouse_action[0] & GUI_PRESSED) && (fabs(hitx - firstx) > 2 || fabs(hity - firsty) > 2)) mouse_action[0] |= GUI_DRAGGED;
+                if((mouse_action[0] & GUI_PRESSED) && (std::fabsf(hitx - firstx) > 2 || std::fabsf(hity - firsty) > 2)) mouse_action[0] |= GUI_DRAGGED;
             }
         }
         else

--- a/src/engine/ui.cpp
+++ b/src/engine/ui.cpp
@@ -1225,7 +1225,7 @@ struct gui : guient
             {
                 hitx = (cursorx - uiorigin.x)/uiscale.x;
                 hity = (cursory - uiorigin.y)/uiscale.y;
-                if((mouse_action[0] & GUI_PRESSED) && (std::fabsf(hitx - firstx) > 2 || std::fabsf(hity - firsty) > 2)) mouse_action[0] |= GUI_DRAGGED;
+                if((mouse_action[0] & GUI_PRESSED) && (std::fabs(hitx - firstx) > 2 || std::fabs(hity - firsty) > 2)) mouse_action[0] |= GUI_DRAGGED;
             }
         }
         else

--- a/src/engine/vertmodel.h
+++ b/src/engine/vertmodel.h
@@ -464,8 +464,8 @@ template<class MDL> struct vertcommands : modelcommands<MDL, struct MDL::vertmes
         }
         else
         {
-            mdl.pitchmin = -360*fabs(mdl.pitchscale) + mdl.pitchoffset;
-            mdl.pitchmax = 360*fabs(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmin = -360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmax = 360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
         }
     }
 

--- a/src/engine/vertmodel.h
+++ b/src/engine/vertmodel.h
@@ -464,8 +464,8 @@ template<class MDL> struct vertcommands : modelcommands<MDL, struct MDL::vertmes
         }
         else
         {
-            mdl.pitchmin = -360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
-            mdl.pitchmax = 360*std::fabsf(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmin = -360*std::fabs(mdl.pitchscale) + mdl.pitchoffset;
+            mdl.pitchmax = 360*std::fabs(mdl.pitchscale) + mdl.pitchoffset;
         }
     }
 

--- a/src/engine/water.cpp
+++ b/src/engine/water.cpp
@@ -22,7 +22,7 @@ static float whscale, whoffset;
     { \
         float angle = (v1-wx1)*(v2-wy1)*(v1-wx2)*(v2-wy2)*whscale+whoffset; \
         float s = angle - int(angle) - 0.5f; \
-        s *= 8 - std::fabsf(s)*16; \
+        s *= 8 - std::fabs(s)*16; \
         float h = WATER_AMPLITUDE*s-WATER_OFFSET; \
         gle::attribf(v1, v2, v3+h); \
         body; \
@@ -42,7 +42,7 @@ static float whscale, whoffset;
 #define VERTWT(vertwt, defbody, body) \
     VERTW(vertwt, defbody, { \
         float v = angle - int(angle+0.25) - 0.25; \
-        v *= 8 - std::fabsf(v)*16; \
+        v *= 8 - std::fabs(v)*16; \
         float duv = 0.5f*v; \
         body; \
     })
@@ -123,7 +123,7 @@ int calcwatersubdiv(int x, int y, int z, int size)
     float dist;
     if(camera1->o.x >= x && camera1->o.x < x + size &&
        camera1->o.y >= y && camera1->o.y < y + size)
-        dist = std::fabsf(camera1->o.z - float(z));
+        dist = std::fabs(camera1->o.z - float(z));
     else
         dist = vec(x + size/2, y + size/2, z + size/2).dist(camera1->o) - size*1.42f/2;
     int subdiv = watersubdiv + int(dist) / (32 << waterlod);
@@ -689,7 +689,7 @@ void queryreflection(Reflection &ref, bool init)
         {
             offset = WATER_OFFSET +
                 (vertwater ? WATER_AMPLITUDE*(camera1->pitch > 0 || m.depth < WATER_AMPLITUDE+0.5f ? -1 : 1) : 0);
-            if(std::fabsf(m.o.z-offset - camera1->o.z) < 0.5f && m.depth > WATER_AMPLITUDE+1.5f)
+            if(std::fabs(m.o.z-offset - camera1->o.z) < 0.5f && m.depth > WATER_AMPLITUDE+1.5f)
                 offset += camera1->pitch > 0 ? -1 : 1;
         }
         drawmaterialquery(m, offset);

--- a/src/engine/water.cpp
+++ b/src/engine/water.cpp
@@ -22,7 +22,7 @@ static float whscale, whoffset;
     { \
         float angle = (v1-wx1)*(v2-wy1)*(v1-wx2)*(v2-wy2)*whscale+whoffset; \
         float s = angle - int(angle) - 0.5f; \
-        s *= 8 - fabs(s)*16; \
+        s *= 8 - std::fabsf(s)*16; \
         float h = WATER_AMPLITUDE*s-WATER_OFFSET; \
         gle::attribf(v1, v2, v3+h); \
         body; \
@@ -42,7 +42,7 @@ static float whscale, whoffset;
 #define VERTWT(vertwt, defbody, body) \
     VERTW(vertwt, defbody, { \
         float v = angle - int(angle+0.25) - 0.25; \
-        v *= 8 - fabs(v)*16; \
+        v *= 8 - std::fabsf(v)*16; \
         float duv = 0.5f*v; \
         body; \
     })
@@ -123,7 +123,7 @@ int calcwatersubdiv(int x, int y, int z, int size)
     float dist;
     if(camera1->o.x >= x && camera1->o.x < x + size &&
        camera1->o.y >= y && camera1->o.y < y + size)
-        dist = fabs(camera1->o.z - float(z));
+        dist = std::fabsf(camera1->o.z - float(z));
     else
         dist = vec(x + size/2, y + size/2, z + size/2).dist(camera1->o) - size*1.42f/2;
     int subdiv = watersubdiv + int(dist) / (32 << waterlod);
@@ -689,7 +689,7 @@ void queryreflection(Reflection &ref, bool init)
         {
             offset = WATER_OFFSET +
                 (vertwater ? WATER_AMPLITUDE*(camera1->pitch > 0 || m.depth < WATER_AMPLITUDE+0.5f ? -1 : 1) : 0);
-            if(fabs(m.o.z-offset - camera1->o.z) < 0.5f && m.depth > WATER_AMPLITUDE+1.5f)
+            if(std::fabsf(m.o.z-offset - camera1->o.z) < 0.5f && m.depth > WATER_AMPLITUDE+1.5f)
                 offset += camera1->pitch > 0 ? -1 : 1;
         }
         drawmaterialquery(m, offset);

--- a/src/engine/world.cpp
+++ b/src/engine/world.cpp
@@ -631,7 +631,7 @@ void entautoview(int *dir)
     v.normalize();
     v.mul(entautoviewdist);
     int t = s + *dir;
-    s = abs(t) % entgroup.length();
+    s = std::abs(t) % entgroup.length();
     if(t<0 && s>0) s = entgroup.length() - s;
     entfocus(entgroup[s],
         v.add(e.o);
@@ -682,8 +682,8 @@ bool dropentity(extentity &e, int drop = -1)
         {
             vec center;
             mmboundbox(e, m, center, radius);
-            radius.x += fabs(center.x);
-            radius.y += fabs(center.y);
+            radius.x += std::fabsf(center.x);
+            radius.y += std::fabsf(center.y);
         }
         radius.z = 0.0f;
     }

--- a/src/engine/world.cpp
+++ b/src/engine/world.cpp
@@ -682,8 +682,8 @@ bool dropentity(extentity &e, int drop = -1)
         {
             vec center;
             mmboundbox(e, m, center, radius);
-            radius.x += std::fabsf(center.x);
-            radius.y += std::fabsf(center.y);
+            radius.x += std::fabs(center.x);
+            radius.y += std::fabs(center.y);
         }
         radius.z = 0.0f;
     }

--- a/src/game/ai.cpp
+++ b/src/game/ai.cpp
@@ -121,7 +121,7 @@ namespace ai
                 offy = yaw-d->yaw, offp = pitch-d->pitch;
             if(offy > 180) offy -= 360;
             else if(offy < -180) offy += 360;
-            if(fabs(offy) <= d->ai->views[0]*skew && fabs(offp) <= d->ai->views[1]*skew) return true;
+            if(std::fabs(offy) <= d->ai->views[0]*skew && std::fabs(offp) <= d->ai->views[1]*skew) return true;
         }
         return false;
     }

--- a/src/game/bomber.cpp
+++ b/src/game/bomber.cpp
@@ -31,7 +31,7 @@ namespace bomber
         float angle = fixrot(a)-fixrot(b);
         while(angle < -180.0f) angle += 360.0f;
         while(angle >= 180.0f) angle -= 360.0f;
-        return fabs(angle);
+        return std::fabs(angle);
     }
 
     VAR(IDF_PERSIST, bombertargetintersect, 0, 1, 1);

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1928,7 +1928,7 @@ namespace client
         const float dy = game::player1.o.y-d->o.y;
         const float dz = game::player1.o.z-d->o.z;
         const float rz = game::player1.aboveeye+game::player1.height;
-        const float fx = (float)fabs(dx), fy = (float)fabs(dy), fz = (float)fabs(dz);
+        const float fx = (float)std::fabs(dx), fy = (float)std::fabs(dy), fz = (float)std::fabs(dz);
         if(fx<r && fy<r && fz<rz && d->state!=CS_SPECTATOR && d->state!=CS_WAITING && d->state!=CS_DEAD)
         {
             if(fx<fy) d->o.y += dy<0 ? r-fy : -(r-fy);  // push aside

--- a/src/game/defend.h
+++ b/src/game/defend.h
@@ -192,7 +192,7 @@ struct defendstate
     {
         if(radius <= 0) radius = enttype[AFFINITY].radius;
         float dx = (b.o.x-o.x), dy = (b.o.y-o.y), dz = (b.o.z-o.z);
-        return dx*dx + dy*dy <= radius*radius && fabs(dz) <= radius;
+        return dx*dx + dy*dy <= radius*radius && std::fabs(dz) <= radius;
     }
 };
 

--- a/src/game/duelmut.h
+++ b/src/game/duelmut.h
@@ -393,7 +393,7 @@ struct duelservmode : servmode
                     {
                         if(m_affinity(gamemode) && duelaffin) // reverse it!
                         {
-                            score &ts = teamscore(abs(duelaffin));
+                            score &ts = teamscore(std::abs(duelaffin));
                             if(duelaffin > 0) ts.total--;
                             else ts.total++;
                             sendf(-1, 1, "ri3", N_SCORE, ts.team, ts.total);

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -770,7 +770,7 @@ namespace entities
                         {
                             loopk(3)
                             {
-                                if((d->vel.v[k] > 1e-1f && rel.v[k] < -1e-1f) || (d->vel.v[k] < -1e-1f && rel.v[k] > 1e-1f) || (fabs(rel.v[k]) > fabs(d->vel.v[k])))
+                                if((d->vel.v[k] > 1e-1f && rel.v[k] < -1e-1f) || (d->vel.v[k] < -1e-1f && rel.v[k] > 1e-1f) || (std::fabs(rel.v[k]) > std::fabs(d->vel.v[k])))
                                     d->vel.v[k] = rel.v[k];
                             }
                             break;
@@ -2244,7 +2244,7 @@ namespace entities
                         attrs.add(game::player1.move);
                         attrs.add(game::player1.strafe);
                         attrs.add(0);
-                        loopi(AC_MAX) if(game::player1.action[i] || (abs(game::player1.actiontime[i]) > lastroutetime))
+                        loopi(AC_MAX) if(game::player1.action[i] || (std::abs(game::player1.actiontime[i]) > lastroutetime))
                             attrs[5] |= (1<<i);
                         int n = newentity(o, int(ROUTE), attrs);
                         if(ents.inrange(lastroutenode)) ents[lastroutenode]->links.add(n);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1384,7 +1384,7 @@ namespace game
         bool burning = burn(d, weap, flags), bleeding = bleed(d, weap, flags), shocking = shock(d, weap, flags), material = flags&HIT_MATERIAL;
         if(!local || burning || bleeding || shocking || material)
         {
-            float scale = isweap(weap) && WF(WK(flags), weap, damage, WS(flags)) != 0 ? abs(damage)/float(WF(WK(flags), weap, damage, WS(flags))) : 1.f;
+            float scale = isweap(weap) && WF(WK(flags), weap, damage, WS(flags)) != 0 ? std::abs(damage)/float(WF(WK(flags), weap, damage, WS(flags))) : 1.f;
             if(hitdealt(flags) && damage != 0 && v == focus) hud::hit(damage, d->o, d, weap, flags);
             if(hitdealt(flags) && damage > 0)
             {
@@ -2255,8 +2255,8 @@ namespace game
     {
         if(yaw < targyaw-180.0f) yaw += 360.0f;
         if(yaw > targyaw+180.0f) yaw -= 360.0f;
-        float offyaw = (rotate < 0 ? fabs(rotate) : (rotate > 0 ? min(float(fabs(targyaw-yaw)), rotate) : fabs(targyaw-yaw)))*yawspeed,
-            offpitch = (rotate < 0 ? fabs(rotate) : (rotate > 0 ? min(float(fabs(targpitch-pitch)), rotate) : fabs(targpitch-pitch)))*pitchspeed;
+        float offyaw = (rotate < 0 ? std::fabs(rotate) : (rotate > 0 ? min(float(std::fabs(targyaw-yaw)), rotate) : std::fabs(targyaw-yaw)))*yawspeed,
+            offpitch = (rotate < 0 ? std::fabs(rotate) : (rotate > 0 ? min(float(std::fabs(targpitch-pitch)), rotate) : std::fabs(targpitch-pitch)))*pitchspeed;
         if(targyaw > yaw)
         {
             yaw += offyaw;
@@ -2341,7 +2341,7 @@ namespace game
             {
                 float steps = bobdist/firstpersonbobstep*M_PI;
                 vec dir = vec(yaw*RAD, 0.f).mul(firstpersonbobside*cosf(steps)*scale);
-                dir.z = firstpersonbobup*(fabs(sinf(steps)) - 1)*scale;
+                dir.z = firstpersonbobup*(std::fabs(sinf(steps)) - 1)*scale;
                 to.add(dir);
             }
         }
@@ -2706,7 +2706,7 @@ namespace game
                     if(adj##x < x - 180.0f) adj##x += 360.0f; \
                     if(adj##x > x + 180.0f) adj##x -= 360.0f; \
                     off##x -= adj##x; \
-                    if(cam->last##x == 0 || (off##x > 0 && cam->last##x < 0) || (off##x < 0 && cam->last##x > 0) || (x##thresh > 0 && (fabs(cam->last##x - off##x) >= x##thresh))) \
+                    if(cam->last##x == 0 || (off##x > 0 && cam->last##x < 0) || (off##x < 0 && cam->last##x > 0) || (x##thresh > 0 && (std::fabs(cam->last##x - off##x) >= x##thresh))) \
                     { \
                         cam->last##x##time = lastmillis; \
                         x##scale = 0; \
@@ -2793,7 +2793,7 @@ namespace game
                 float steps = bobdist/firstpersonbobstep*M_PI, dist = raycube(c->o, dir, firstpersonbobfocusmaxdist, RAY_CLIPMAT|RAY_POLY), yaw, pitch;
                 if(dist < 0 || dist > firstpersonbobfocusmaxdist) dist = firstpersonbobfocusmaxdist;
                 else if(dist < firstpersonbobfocusmindist) dist = firstpersonbobfocusmindist;
-                vectoyawpitch(vec(firstpersonbobside*cosf(steps), dist, firstpersonbobup*(fabs(sinf(steps)) - 1)), yaw, pitch);
+                vectoyawpitch(vec(firstpersonbobside*cosf(steps), dist, firstpersonbobup*(std::fabs(sinf(steps)) - 1)), yaw, pitch);
                 c->yaw -= yaw*firstpersonbobfocus*scale;
                 c->pitch -= pitch*firstpersonbobfocus*scale;
                 c->roll += (1 - firstpersonbobfocus)*firstpersonbobroll*cosf(steps)*scale;
@@ -3041,7 +3041,7 @@ namespace game
             {
                 float steps = swaydist/(firstpersonbob ? firstpersonbobstep : firstpersonswaystep)*M_PI;
                 vec dir = vec(d->yaw*RAD, 0.f).mul(firstpersonswayside*cosf(steps));
-                dir.z = firstpersonswayup*(fabs(sinf(steps)) - 1);
+                dir.z = firstpersonswayup*(std::fabs(sinf(steps)) - 1);
                 o.add(dir).add(swaydir).add(swaypush);
             }
         }

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -3045,7 +3045,7 @@ namespace hud
 
                 loopi(AC_TOTAL) if(inventoryinputfilter&(1<<i))
                 {
-                    bool active = game::focus->action[i] || (inventoryinputlinger&(1<<i) && game::focus->actiontime[i] && lastmillis-abs(game::focus->actiontime[i]) <= inventoryinputdelay);
+                    bool active = game::focus->action[i] || (inventoryinputlinger&(1<<i) && game::focus->actiontime[i] && lastmillis-std::abs(game::focus->actiontime[i]) <= inventoryinputdelay);
                     sy += draw_textf("\fs\fw\f{\f[%d]%s}\fS", x+s/2, y-sy, 0, 0, 255, 255, 255, int(blend*inventoryinputblend*255), TEXT_CENTER_UP, -1, -1, 1,
                             active ? inventoryinputactive : inventoryinputcolour, actionnames[i]);
                 }
@@ -3188,7 +3188,7 @@ namespace hud
                 if(game::player1.state == CS_EDITING)
                 {
                     cy[1] -= draw_textf("cube:%s%d corner:%d orient:%d grid:%d%s", cx[1], cy[1], 0, 0, 255, 255, 255, bf, TEXT_RIGHT_UP, -1, bs, 1,
-                            selchildcount<0 ? "1/" : "", abs(selchildcount), sel.corner, sel.orient, sel.grid, showmat && selchildmat > 0 ? getmaterialdesc(selchildmat, " mat:") : "");
+                            selchildcount<0 ? "1/" : "", std::abs(selchildcount), sel.corner, sel.orient, sel.grid, showmat && selchildmat > 0 ? getmaterialdesc(selchildmat, " mat:") : "");
 
                     cy[1] -= draw_textf("sel:%d,%d,%d %d,%d,%d (%d,%d,%d,%d)", cx[1], cy[1], 0, 0, 255, 255, 255, bf, TEXT_RIGHT_UP, -1, bs, 1,
                             sel.o.x, sel.o.y, sel.o.z, sel.s.x, sel.s.y, sel.s.z,
@@ -3521,23 +3521,23 @@ namespace hud
         if(!progressing)
         {
             vec colour = vec(1, 1, 1);
-            if(commandfade && (commandmillis > 0 || totalmillis-abs(commandmillis) <= commandfade))
+            if(commandfade && (commandmillis > 0 || totalmillis-std::abs(commandmillis) <= commandfade))
             {
-                float a = min(float(totalmillis-abs(commandmillis))/float(commandfade), 1.f)*commandfadeamt;
+                float a = min(float(totalmillis-std::abs(commandmillis))/float(commandfade), 1.f)*commandfadeamt;
                 if(commandmillis > 0) a = 1.f-a;
                 else a += (1.f-commandfadeamt);
                 loopi(3) if(a < colour[i]) colour[i] *= a;
             }
-            if(compassfade && (compassmillis > 0 || totalmillis-abs(compassmillis) <= compassfade))
+            if(compassfade && (compassmillis > 0 || totalmillis-std::abs(compassmillis) <= compassfade))
             {
-                float a = min(float(totalmillis-abs(compassmillis))/float(compassfade), 1.f)*compassfadeamt;
+                float a = min(float(totalmillis-std::abs(compassmillis))/float(compassfade), 1.f)*compassfadeamt;
                 if(compassmillis > 0) a = 1.f-a;
                 else a += (1.f-compassfadeamt);
                 loopi(3) if(a < colour[i]) colour[i] *= a;
             }
-            if(uifade && (uimillis > 0 || totalmillis-abs(uimillis) <= uifade))
+            if(uifade && (uimillis > 0 || totalmillis-std::abs(uimillis) <= uifade))
             {
-                float n = min(float(totalmillis-abs(uimillis))/float(uifade), 1.f), a = n*uifadeamt;
+                float n = min(float(totalmillis-std::abs(uimillis))/float(uifade), 1.f), a = n*uifadeamt;
                 if(uimillis > 0) a = 1.f-a;
                 else a += (1.f-uifadeamt);
                 loopi(3) if(a < colour[i]) colour[i] *= a;
@@ -3581,7 +3581,7 @@ namespace hud
                 drawblend(0, 0, hudwidth, hudheight, colour.x, colour.y, colour.z);
                 usetexturing(true);
                 float amt = (colour.x+colour.y+colour.z)/3.f;
-                if(commandfadeskew < 1 && (!commandmillis || (commandmillis < 0 && totalmillis-abs(commandmillis) > commandfade)))
+                if(commandfadeskew < 1 && (!commandmillis || (commandmillis < 0 && totalmillis-std::abs(commandmillis) > commandfade)))
                     consolefade *= amt+((1.f-amt)*commandfadeskew);
                 fade *= amt;
             }

--- a/src/game/physics.cpp
+++ b/src/game/physics.cpp
@@ -397,7 +397,7 @@ namespace physics
         oldvel.add(d->falling);
         if(dir.dot(floor) >= 0)
         {
-            if(d->physstate < PHYS_SLIDE || fabs(dir.dot(d->floor)) > 0.01f*dir.magnitude()) return;
+            if(d->physstate < PHYS_SLIDE || std::fabs(dir.dot(d->floor)) > 0.01f*dir.magnitude()) return;
             d->vel.projectxy(floor, 0.0f);
         }
         else d->vel.projectxy(floor);
@@ -507,7 +507,7 @@ namespace physics
         stepdir.normalize();
 
         vec old(d->o);
-        d->o.add(vec(stepdir).mul(stairheight/fabs(stepdir.z))).z -= stairheight;
+        d->o.add(vec(stepdir).mul(stairheight/std::fabs(stepdir.z))).z -= stairheight;
         d->zmargin = -stairheight;
         if(collide(d, vec(0, 0, -1), slopez))
         {
@@ -857,7 +857,7 @@ namespace physics
                 d->o = oldpos;
                 if(!collided || hitplayer || collidewall.iszero()) continue;
                 vec face = vec(collidewall).normalize();
-                if(fabs(face.z) <= impulseparkournorm)
+                if(std::fabs(face.z) <= impulseparkournorm)
                 {
                     bool cankick = d->action[AC_SPECIAL] && canimpulse(d, A_A_PARKOUR, true), parkour = cankick && !onfloor && !d->onladder;
                     float yaw = 0, pitch = 0;
@@ -865,7 +865,7 @@ namespace physics
                     float off = yaw-d->yaw;
                     if(off > 180) off -= 360;
                     else if(off < -180) off += 360;
-                    bool iskick = impulsekick > 0 && fabs(off) >= impulsekick, vault = false;
+                    bool iskick = impulsekick > 0 && std::fabs(off) >= impulsekick, vault = false;
                     if(cankick && iskick)
                     {
                         float space = d->height+d->aboveeye, m = min(impulsevaultmin, impulsevaultmax), n = max(impulsevaultmin, impulsevaultmax);
@@ -894,7 +894,7 @@ namespace physics
                         if(mag > 0)
                         {
                             vec rft;
-                            vecfromyawpitch(d->yaw, vault || d->actortype >= A_BOT || !kickupstyle ? kickupangle : fabs(d->pitch), 1, 0, rft);
+                            vecfromyawpitch(d->yaw, vault || d->actortype >= A_BOT || !kickupstyle ? kickupangle : std::fabs(d->pitch), 1, 0, rft);
                             rft.reflect(face);
                             d->vel = vec(rft).mul(mag).add(keepvel);
                             d->doimpulse(cost, vault ? IM_T_VAULT : IM_T_KICK, lastmillis);

--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -539,7 +539,7 @@ namespace projs
                 {
                     float rmax = 180.f+reflectivity, rmin = 180.f-reflectivity,
                         off = aim[i][1]-aim[i][0];
-                    if(fabs(off) <= rmax && fabs(off) >= rmin)
+                    if(std::fabs(off) <= rmax && std::fabs(off) >= rmin)
                     {
                         if(off > 0.f ? off > 180.f : off < -180.f)
                             aim[i][1] += rmax-off;
@@ -1860,7 +1860,7 @@ namespace projs
                     proj.o = orig; // continues below
                 }
             }
-            if(proj.projtype == PRJ_SHOT && (WF(WK(proj.flags), proj.weap, grab, WS(proj.flags))&(d ? 2 : 1)) && (proj.owner == &game::player1 || proj.owner->ai) && proj.owner->state == CS_ALIVE && (d || fabs(proj.norm.z) <= impulseparkournorm) && physics::canimpulse(proj.owner, A_A_PARKOUR, true))
+            if(proj.projtype == PRJ_SHOT && (WF(WK(proj.flags), proj.weap, grab, WS(proj.flags))&(d ? 2 : 1)) && (proj.owner == &game::player1 || proj.owner->ai) && proj.owner->state == CS_ALIVE && (d || std::fabs(proj.norm.z) <= impulseparkournorm) && physics::canimpulse(proj.owner, A_A_PARKOUR, true))
             {
                 gameent *e = (gameent *)proj.owner;
                 vec keepvel = vec(e->vel).add(e->falling);
@@ -1873,7 +1873,7 @@ namespace projs
                     {
                         case 0: pitch = e->pitch; break;
                         case 1: pitch = -e->pitch; break;
-                        case 2: pitch = fabs(e->pitch); break;
+                        case 2: pitch = std::fabs(e->pitch); break;
                         case 3:
                             if(d)
                             {

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2298,7 +2298,7 @@ namespace server
     {
         defvformatbigstring(str, s, s);
         srvmsgf(r >= 0 ? -1 : -2, "%s", str);
-        relayf(abs(r), "%s", str);
+        relayf(std::abs(r), "%s", str);
     }
 
     void listdemos(int cn)

--- a/src/shared/geom.cpp
+++ b/src/shared/geom.cpp
@@ -58,7 +58,7 @@ bool matrix4::invert(const matrix4 &m, double mindet)
            det4 = -det3x3(a2, a3, a4, b2, b3, b4, c2, c3, c4),
            det = a1*det1 + b1*det2 + c1*det3 + d1*det4;
 
-    if(fabs(det) < mindet) return false;
+    if(std::fabs(det) < mindet) return false;
 
     double invdet = 1/det;
 
@@ -133,7 +133,7 @@ bool linecylinderintersect(const vec &from, const vec &to, const vec &start, con
           a = dd*nn - nd*nd,
           k = m.squaredlen() - radius*radius,
           c = dd*k - md*md;
-    if(fabs(a) < 0.005f)
+    if(std::fabs(a) < 0.005f)
     {
         if(c > 0) return false;
         if(md < 0) dist = -mn / nn;

--- a/src/shared/geom.h
+++ b/src/shared/geom.h
@@ -43,7 +43,7 @@ struct vec2
     vec2 &max(const vec2 &o) { x = ::max(x, o.x); y = ::max(y, o.y); return *this; }
     vec2 &min(float f)       { x = ::min(x, f); y = ::min(y, f); return *this; }
     vec2 &max(float f)       { x = ::max(x, f); y = ::max(y, f); return *this; }
-    vec2 &abs() { x = fabs(x); y = fabs(y); return *this; }
+    vec2 &abs() { x = std::fabs(x); y = std::fabs(y); return *this; }
     vec2 &clamp(float l, float h) { x = ::clamp(x, l, h); y = ::clamp(y, l, h); return *this; }
     vec2 &reflect(const vec2 &n) { float k = 2*dot(n); x -= k*n.x; y -= k*n.y; return *this; }
     vec2 &lerp(const vec2 &b, float t) { x += (b.x-x)*t; y += (b.y-y)*t; return *this; }
@@ -101,7 +101,7 @@ struct vec
     float squaredlen() const { return x*x + y*y + z*z; }
     template<class T> float dot2(const T &o) const { return x*o.x + y*o.y; }
     float dot(const vec &o) const { return x*o.x + y*o.y + z*o.z; }
-    float absdot(const vec &o) const { return fabs(x*o.x) + fabs(y*o.y) + fabs(z*o.z); }
+    float absdot(const vec &o) const { return std::fabs(x*o.x) + std::fabs(y*o.y) + std::fabs(z*o.z); }
     vec &mul(const vec &o)   { x *= o.x; y *= o.y; z *= o.z; return *this; }
     vec &mul(float f)        { x *= f; y *= f; z *= f; return *this; }
     vec &div(const vec &o)   { x /= o.x; y /= o.y; z /= o.z; return *this; }
@@ -120,7 +120,7 @@ struct vec
     vec &max(const vec &o)   { x = ::max(x, o.x); y = ::max(y, o.y); z = ::max(z, o.z); return *this; }
     vec &min(float f)        { x = ::min(x, f); y = ::min(y, f); z = ::min(z, f); return *this; }
     vec &max(float f)        { x = ::max(x, f); y = ::max(y, f); z = ::max(z, f); return *this; }
-    vec &abs() { x = fabs(x); y = fabs(y); z = fabs(z); return *this; }
+    vec &abs() { x = std::fabs(x); y = std::fabs(y); z = std::fabs(z); return *this; }
     vec &clamp(float l, float h) { x = ::clamp(x, l, h); y = ::clamp(y, l, h); z = ::clamp(z, l, h); return *this; }
     float magnitude2() const { return sqrtf(dot2(*this)); }
     float magnitude() const  { return sqrtf(squaredlen()); }
@@ -192,7 +192,7 @@ struct vec
 
     void orthogonal(const vec &d)
     {
-        *this = fabs(d.x) > fabs(d.z) ? vec(-d.y, d.x, 0) : vec(0, -d.z, d.y);
+        *this = std::fabs(d.x) > std::fabs(d.z) ? vec(-d.y, d.x, 0) : vec(0, -d.z, d.y);
     }
 
     void orthonormalize(vec &s, vec &t) const
@@ -1181,7 +1181,7 @@ struct ivec
     ivec &max(const ivec &o) { x = ::max(x, o.x); y = ::max(y, o.y); z = ::max(z, o.z); return *this; }
     ivec &min(int n) { x = ::min(x, n); y = ::min(y, n); z = ::min(z, n); return *this; }
     ivec &max(int n) { x = ::max(x, n); y = ::max(y, n); z = ::max(z, n); return *this; }
-    ivec &abs() { x = ::abs(x); y = ::abs(y); z = ::abs(z); return *this; }
+    ivec &abs() { x = std::abs(x); y = std::abs(y); z = std::abs(z); return *this; }
     ivec &clamp(int l, int h) { x = ::clamp(x, l, h); y = ::clamp(y, l, h); z = ::clamp(z, l, h); return *this; }
     ivec &cross(const ivec &a, const ivec &b) { x = a.y*b.z-a.z*b.y; y = a.z*b.x-a.x*b.z; z = a.x*b.y-a.y*b.x; return *this; }
     int dot(const ivec &o) const { return x*o.x + y*o.y + z*o.z; }
@@ -1240,7 +1240,7 @@ struct ivec2
     ivec2 &max(const ivec2 &o) { x = ::max(x, o.x); y = ::max(y, o.y); return *this; }
     ivec2 &min(int n) { x = ::min(x, n); y = ::min(y, n); return *this; }
     ivec2 &max(int n) { x = ::max(x, n); y = ::max(y, n); return *this; }
-    ivec2 &abs() { x = ::abs(x); y = ::abs(y); return *this; }
+    ivec2 &abs() { x = std::abs(x); y = std::abs(y); return *this; }
     int dot(const ivec2 &o) const { return x*o.x + y*o.y; }
     int cross(const ivec2 &o) const { return x*o.y - y*o.x; }
 };

--- a/src/shared/stream.cpp
+++ b/src/shared/stream.cpp
@@ -239,7 +239,7 @@ int crcstream(stream *f)
     size_t len = 0;
     char *buf = loadstream(f, &len, false);
     if(!buf) return 0;
-    int crc = abs(int(crc32(0, (const Bytef *)buf, len)));
+    int crc = std::abs(int(crc32(0, (const Bytef *)buf, len)));
     delete[] buf;
     return crc;
 }


### PR DESCRIPTION
I'm not sure where the current `abs()` and `fabs()` functions originated from, but I replaced them with `std::abs()` and `std::fabs()`