### PR TITLE
Add state for active objects to GUI

### DIFF
--- a/src/engine/menus.cpp
+++ b/src/engine/menus.cpp
@@ -638,7 +638,9 @@ void ui_body(uint *contents, char *action, char *altact, uint *onhover)
     cgui->pushlist(action && *action ? true : false);
     execute(contents);
     int ret = cgui->poplist();
-    if(ret&GUI_UP)
+    if(guilayoutpass) return;
+    bool active = cgui->unique_object_active(ret & GUI_ROLLOVER);
+    if(ret&GUI_UP && active)
     {
         char *act = NULL;
         if(ret&GUI_ALT && altact && *altact) act = altact;

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -568,6 +568,8 @@ struct guient
     virtual void start(int starttime, int *tab = NULL, bool allowinput = true, bool wantstitle = true, bool wantsbgfx = true) = 0;
     virtual void end() = 0;
 
+    virtual bool unique_object_active(bool hit) = 0;
+
     virtual int text(const char *text, int color = 0xFFFFFF, const char *icon = NULL, int icolour = 0xFFFFFF, int wrap = -1, bool faded = false, const char *oicon = NULL, int ocolor = 0xFFFFFF) = 0;
     int textf(const char *fmt, int color = 0xFFFFFF, const char *icon = NULL, int icolour = 0xFFFFFF, int wrap = -1, bool faded = false, const char *oicon = NULL, int ocolor = 0xFFFFFF, ...) PRINTFARGS(2, 10)
     {


### PR DESCRIPTION
Fixes #200 about sliders that only work when the mouse is over them.

This commit adds two things; state variables (`*childpath`) with
function that modifies it, and modifications to relevant GUI object
(e.g. button, slider) functions so that they use that function to
register as a unique object and find out whether they are active.

The GUI code now keeps track of the "path" to each object.  By "path" I
mean e.g. go to the 3rd top-level child and then to it's 2nd child.
This is similar to what it looks like they do in Red Eclipse 2.  This is
not a perfect solution because it's possible that these paths change
when objects are added or removed but it is much better than just giving
each object a simple number as ID because when something is changed
inside one list it doesn't change the path to an object that is not a
child of that list.

The modifications to the GUI objects are usually done so that the
mouse-up action only happens if the object is the active object (the
mouse was pressed down on that object).