### PR TITLE
Crosshair separation

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -223,7 +223,6 @@ extern float curfogstart, curfogend;
 
 extern float cursorx, cursory;
 extern float crosshairx, crosshairy;
-extern vec cursordir;
 extern vec crosshairdir;
 
 extern GLenum colormask[3];

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -222,7 +222,9 @@ extern int fog;
 extern float curfogstart, curfogend;
 
 extern float cursorx, cursory;
+extern float crosshairx, crosshairy;
 extern vec cursordir;
+extern vec crosshairdir;
 
 extern GLenum colormask[3];
 #define COLORMASK colormask[0], colormask[1], colormask[2]

--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -1855,7 +1855,6 @@ void drawfadedslice(float start, float length, float x, float y, float size, flo
 
 float cursorx = 0.5f, cursory = 0.5f;
 float crosshairx = 0.5f, crosshairy = 0.5f;
-vec cursordir(0, 0, 0);
 vec crosshairdir(0, 0, 0);
 
 struct framebuffercopy

--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -1854,7 +1854,9 @@ void drawfadedslice(float start, float length, float x, float y, float size, flo
 }
 
 float cursorx = 0.5f, cursory = 0.5f;
+float crosshairx = 0.5f, crosshairy = 0.5f;
 vec cursordir(0, 0, 0);
+vec crosshairdir(0, 0, 0);
 
 struct framebuffercopy
 {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2228,19 +2228,19 @@ namespace game
                     if(vectocursor(pos, loc.x, loc.y, loc.z))
                     {
                         float amt = curtime/float(thirdpersoninterp);
-                        cursorx = clamp(cursorx+((loc.x-cursorx)*amt), 0.f, 1.f);
-                        cursory = clamp(cursory+((loc.y-cursory)*amt), 0.f, 1.f);
+                        crosshairx = clamp(crosshairx+((loc.x-crosshairx)*amt), 0.f, 1.f);
+                        crosshairy = clamp(crosshairy+((loc.y-crosshairy)*amt), 0.f, 1.f);
                     }
                     break;
                 }
                 case 2:
                 {
-                    cursorx = thirdpersoncursorx;
-                    cursory = thirdpersoncursory;
+                    crosshairx = thirdpersoncursorx;
+                    crosshairy = thirdpersoncursory;
                     break;
                 }
             }
-            vecfromcursor(cursorx, cursory, 1.f, cursordir);
+            vecfromcursor(crosshairx, crosshairy, 1.f, crosshairdir);
         }
     }
 
@@ -2973,7 +2973,7 @@ namespace game
             if(thirdpersoncursor != 1 && pthird)
             {
                 float yaw = camera1->yaw, pitch = camera1->pitch;
-                vectoyawpitch(cursordir, yaw, pitch);
+                vectoyawpitch(crosshairdir, yaw, pitch);
                 findorientation(camera1->o, yaw, pitch, worldpos);
             }
             else findorientation(focus->o, focus->yaw, focus->pitch, worldpos);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2802,11 +2802,12 @@ namespace game
         }
     }
 
-    void resetcamera(bool cam, bool input)
+    void resetcamera(bool cam)
     {
         lastcamera = 0;
         zoomset(false, 0);
-        if(input && !hud::hasinput(true)) resetcursor();
+        crosshairx = 0.5f;
+        crosshairy = 0.5f;
         checkcamera();
         if(cam || !focus)
         {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1663,7 +1663,7 @@ namespace hud
     extern void drawindicator(int weap, int x, int y, int s);
     extern void drawclip(int weap, int x, int y, float s);
     extern void drawpointertex(const char *tex, int x, int y, int s, float r = 1, float g = 1, float b = 1, float fade = 1);
-    extern void drawpointer(int w, int h, int index);
+    extern void drawpointer(int w, int h, int pointertype);
     extern int numteamkills();
     extern int radarrange();
     extern void drawblip(const char *tex, float area, int w, int h, float s, float blend, int style, const vec &pos, const vec &colour = vec(1, 1, 1), const char *font = "reduced", bool rotate = true, const char *text = NULL, ...);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1744,7 +1744,7 @@ namespace game
     extern float zoom_ratio();
     extern void zoomview(bool down);
     extern bool tvmode(bool check = true, bool force = true);
-    extern void resetcamera(bool cam = true, bool input = true);
+    extern void resetcamera(bool cam = true);
     extern void resetworld();
     extern void resetstate();
     extern void hiteffect(int weap, int flags, int damage, gameent *d, gameent *v, vec &dir, vec &vel, float dist, bool local = false);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1662,8 +1662,6 @@ namespace hud
     extern bool chkcond(int val, bool cond);
     extern void drawindicator(int weap, int x, int y, int s);
     extern void drawclip(int weap, int x, int y, float s);
-    extern void drawpointertex(const char *tex, int x, int y, int s, float r = 1, float g = 1, float b = 1, float fade = 1);
-    extern void drawpointer(int w, int h, int pointertype);
     extern int numteamkills();
     extern int radarrange();
     extern void drawblip(const char *tex, float area, int w, int h, float s, float blend, int style, const vec &pos, const vec &colour = vec(1, 1, 1), const char *font = "reduced", bool rotate = true, const char *text = NULL, ...);

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1742,15 +1742,6 @@ namespace hud
 
     void drawlast()
     {
-        if(!progressing)
-        {
-            hudmatrix.ortho(0, hudwidth, hudheight, 0, -1, 1);
-            flushhudmatrix();
-            glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            draw_crosshair(hudwidth, hudheight, choose_crosshair_type());
-            glDisable(GL_BLEND);
-        }
         if(!progressing && showhud)
         {
             hudmatrix.ortho(0, hudwidth, hudheight, 0, -1, 1);
@@ -3543,6 +3534,11 @@ namespace hud
         float fade = hudblend, consolefade = hudblend;
         if(!progressing)
         {
+            glEnable(GL_BLEND);
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            draw_crosshair(hudwidth, hudheight, choose_crosshair_type());
+            glDisable(GL_BLEND);
+
             vec colour = vec(1, 1, 1);
             if(commandfade && (commandmillis > 0 || totalmillis-abs(commandmillis) <= commandfade))
             {

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1389,8 +1389,8 @@ namespace hud
                 if(accskew > 0) fade /= accskew;
             }
         }
-        int cx = int(hudwidth * cursorx);
-        int cy = int(hudheight * cursory);
+        int cx = int(hudwidth * crosshairx);
+        int cy = int(hudheight * crosshairy);
 
         drawpointertex(getpointer(pointertype, game::focus->weapselect), cx-size/2, cy-size/2, size, color.r, color.g, color.b, fade*hudblend);
         if(pointertype > POINTER_GUI)

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -3534,10 +3534,13 @@ namespace hud
         float fade = hudblend, consolefade = hudblend;
         if(!progressing)
         {
-            glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            draw_crosshair(hudwidth, hudheight, choose_crosshair_type());
-            glDisable(GL_BLEND);
+            if(compassmillis <= 0)
+            {
+                glEnable(GL_BLEND);
+                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                draw_crosshair(hudwidth, hudheight, choose_crosshair_type());
+                glDisable(GL_BLEND);
+            }
 
             vec colour = vec(1, 1, 1);
             if(commandfade && (commandmillis > 0 || totalmillis-abs(commandmillis) <= commandfade))

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -893,9 +893,9 @@ namespace hud
         POINTER_HAIR, POINTER_TEAM, POINTER_ZOOM, POINTER_HIT, POINTER_MAX
     };
 
-    const char *getpointer(int index, int weap = -1)
+    const char *getpointer(int pointertype, int weap = -1)
     {
-        switch(index)
+        switch(pointertype)
         {
             case POINTER_RELATIVE: return pointertex;
             case POINTER_GUI:
@@ -1310,34 +1310,36 @@ namespace hud
         }
     }
 
-    void drawpointer(int w, int h, int index)
+    void drawpointer(int w, int h, int pointertype)
     {
-        int cs = int((index == POINTER_GUI ? cursorsize : crosshairsize)*hudsize);
-        float fade = index == POINTER_GUI ? cursorblend : crosshairblend;
-        vec c(1, 1, 1);
-        if(game::focus->state == CS_ALIVE && index >= POINTER_HAIR)
+        int size = int((pointertype == POINTER_GUI ? cursorsize : crosshairsize)*hudsize);
+        float fade = pointertype == POINTER_GUI ? cursorblend : crosshairblend;
+        vec color(1, 1, 1);
+        if(game::focus->state == CS_ALIVE && pointertype >= POINTER_HAIR)
         {
-            if(crosshairweapons&2) c = vec::hexcolor(W(game::focus->weapselect, colour));
-            if(index == POINTER_ZOOM && game::inzoom())
+            if(crosshairweapons&2) color = vec::hexcolor(W(game::focus->weapselect, colour));
+            if(pointertype == POINTER_ZOOM && game::inzoom())
             {
-                int off = int(zoomcrosshairsize*hudsize)-cs;
+                int off = int(zoomcrosshairsize*hudsize)-size;
                 // Focused zoom ratio
                 float zr = game::zoom_ratio();
-                cs += int(off * zr);
+                size += int(off * zr);
                 fade += (zoomcrosshairblend - fade) * zr;
             }
-            if(crosshairtone) skewcolour(c.r, c.g, c.b, crosshairtone);
-            int heal = m_health(game::gamemode, game::mutators, game::focus->actortype);
-            if(crosshairflash && game::focus->state == CS_ALIVE && game::focus->health < heal)
+            if(crosshairtone) skewcolour(color.r, color.g, color.b, crosshairtone);
+            int full_health = m_health(game::gamemode, game::mutators, game::focus->actortype);
+            if(crosshairflash && game::focus->state == CS_ALIVE && game::focus->health < full_health)
             {
-                int millis = lastmillis%1000;
-                float amt = (millis <= 500 ? millis/500.f : 1.f-((millis-500)/500.f))*clamp(float(heal-game::focus->health)/float(heal), 0.f, 1.f);
-                flashcolour(c.r, c.g, c.b, 1.f, 0.f, 0.f, amt);
+                int millis = lastmillis % 1000;
+                float amt_ratio = millis <= 500 ? millis / 500.f : 1.f - ((millis - 500) / 500.f);
+                float health_ratio = clamp(float(full_health - game::focus->health) / float(full_health), 0.f, 1.f);
+                float amt = amt_ratio * health_ratio;
+                flashcolour(color.r, color.g, color.b, 1.f, 0.f, 0.f, amt);
             }
             if(crosshairthrob > 0 && regentime && game::focus->lastregen && lastmillis-game::focus->lastregen <= regentime)
             {
-                float skew = clamp((lastmillis-game::focus->lastregen)/float(regentime/2), 0.f, 2.f);
-                cs += int(cs*(skew > 1.f ? 1.f-skew : skew)*(crosshairthrob*(game::focus->lastregenamt >= 0 ? 1 : -1)));
+                float skew = clamp((lastmillis - game::focus->lastregen) / float(regentime / 2), 0.f, 2.f);
+                size += int(size*(skew > 1.f ? 1.f-skew : skew)*(crosshairthrob*(game::focus->lastregenamt >= 0 ? 1 : -1)));
             }
             if(showcrosshair >= 2)
             {
@@ -1346,10 +1348,10 @@ namespace hud
             }
         }
         int cx = int(hudwidth*cursorx), cy = int(hudheight*cursory);
-        if(index != POINTER_GUI)
+        if(pointertype != POINTER_GUI)
         {
-            drawpointertex(getpointer(index, game::focus->weapselect), cx-cs/2, cy-cs/2, cs, c.r, c.g, c.b, fade*hudblend);
-            if(index > POINTER_GUI)
+            drawpointertex(getpointer(pointertype, game::focus->weapselect), cx-size/2, cy-size/2, size, color.r, color.g, color.b, fade*hudblend);
+            if(pointertype > POINTER_GUI)
             {
                 if(minimal(showcirclebar)) drawcirclebar(cx, cy, hudsize);
                 if(game::focus->state == CS_ALIVE && game::focus->hasweap(game::focus->weapselect, m_weapon(game::focus->actortype, game::gamemode, game::mutators)))
@@ -1359,10 +1361,10 @@ namespace hud
                 }
                 if(crosshairhitspeed && totalmillis-game::focus->lasthit <= crosshairhitspeed)
                 {
-                    vec c2(1, 1, 1);
-                    if(hitcrosshairtone) skewcolour(c2.r, c2.g, c2.b, hitcrosshairtone);
-                    else c2 = c;
-                    drawpointertex(getpointer(POINTER_HIT, game::focus->weapselect), cx-cs/2, cy-cs/2, cs, c2.r, c2.g, c2.b, crosshairblend*hudblend);
+                    vec color2(1, 1, 1);
+                    if(hitcrosshairtone) skewcolour(color2.r, color2.g, color2.b, hitcrosshairtone);
+                    else color2 = color;
+                    drawpointertex(getpointer(POINTER_HIT, game::focus->weapselect), cx-size/2, cy-size/2, size, color2.r, color2.g, color2.b, crosshairblend*hudblend);
                 }
                 if(crosshairdistance && game::focus->state == CS_EDITING) draw_textf("\fa%.1f\fwm", cx+crosshairdistancex, cy+crosshairdistancey, 0, 0, 255, 255, 255, int(hudblend*255), TEXT_RIGHT_JUSTIFY, -1, -1, 1, game::focus->o.dist(worldpos)/8.f);
             }
@@ -1371,37 +1373,37 @@ namespace hud
         {
             if(ui_cursor_type == 2)
             {
-                cy -= cs/2;
-                cx -= cs/2;
+                cy -= size / 2;
+                cx -= size / 2;
             }
-            drawpointertex(getpointer(index, game::focus->weapselect), cx, cy, cs, c.r, c.g, c.b, fade*hudblend);
+            drawpointertex(getpointer(pointertype, game::focus->weapselect), cx, cy, size, color.r, color.g, color.b, fade*hudblend);
         }
     }
 
     void drawpointers(int w, int h)
     {
-        int index = POINTER_NONE;
-        if(hasinput()) index = !hasinput(true) || commandmillis > 0 ? POINTER_NONE : POINTER_GUI;
+        int pointertype = POINTER_NONE;
+        if(hasinput()) pointertype = !hasinput(true) || commandmillis > 0 ? POINTER_NONE : POINTER_GUI;
         else if(!showhud || !showcrosshair || game::focus->state == CS_DEAD || !gs_playing(game::gamestate) || client::waiting() || (game::thirdpersonview(true) && game::focus != &game::player1))
-            index = POINTER_NONE;
-        else if(game::focus->state == CS_EDITING) index = POINTER_EDIT;
-        else if(game::focus->state >= CS_SPECTATOR) index = POINTER_SPEC;
-        else if(game::inzoom()) index = POINTER_ZOOM;
+            pointertype = POINTER_NONE;
+        else if(game::focus->state == CS_EDITING) pointertype = POINTER_EDIT;
+        else if(game::focus->state >= CS_SPECTATOR) pointertype = POINTER_SPEC;
+        else if(game::inzoom()) pointertype = POINTER_ZOOM;
         else if(m_team(game::gamemode, game::mutators))
         {
             vec pos = game::focus->headpos();
             gameent *d = game::intersectclosest(pos, worldpos, game::focus);
-            if(d && d->actortype < A_ENEMY && d->team == game::focus->team) index = POINTER_TEAM;
-            else index = POINTER_HAIR;
+            if(d && d->actortype < A_ENEMY && d->team == game::focus->team) pointertype = POINTER_TEAM;
+            else pointertype = POINTER_HAIR;
         }
-        else index = POINTER_HAIR;
-        if(index > POINTER_NONE)
+        else pointertype = POINTER_HAIR;
+        if(pointertype > POINTER_NONE)
         {
             hudmatrix.ortho(0, hudwidth, hudheight, 0, -1, 1);
             flushhudmatrix();
             glEnable(GL_BLEND);
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            drawpointer(w, h, index);
+            drawpointer(w, h, pointertype);
             glDisable(GL_BLEND);
         }
     }
@@ -2604,8 +2606,8 @@ namespace hud
         Texture *t = tex && *tex ? textureload(tex, 3, true, false) : NULL;
         if(t == notexture) t = NULL;
         float q = clamp(skew, 0.f, 1.f), cr = left ? r : r*q, cg = left ? g : g*q, cb = left ? b : b*q, s = size*skew, w = t ? float(t->w)/float(t->h)*s : s;
-        int heal = m_health(game::gamemode, game::mutators, game::focus->actortype), sy = int(s), cx = x, cy = y, cs = int(s), cw = int(w);
-        bool pulse = inventoryflash && game::focus->state == CS_ALIVE && game::focus->health < heal;
+        int full_health = m_health(game::gamemode, game::mutators, game::focus->actortype), sy = int(s), cx = x, cy = y, cs = int(s), cw = int(w);
+        bool pulse = inventoryflash && game::focus->state == CS_ALIVE && game::focus->health < full_health;
         if(bg && sub == 0 && inventorybg)
         {
             Texture *u = textureload(inventorybg == 2 ? inventorybigtex : inventorytex, 3);
@@ -2615,7 +2617,7 @@ namespace hud
             if(pulse)
             {
                 int millis = lastmillis%1000;
-                float amt = (millis <= 500 ? millis/500.f : 1.f-((millis-500)/500.f))*clamp(float(heal-game::focus->health)/float(heal), 0.f, 1.f);
+                float amt = (millis <= 500 ? millis/500.f : 1.f-((millis-500)/500.f))*clamp(float(full_health-game::focus->health)/float(full_health), 0.f, 1.f);
                 flashcolourf(gr, gg, gb, gf, 1.f, 0.f, 0.f, 1.f, amt);
                 glow += int(s*inventoryglow*amt);
             }
@@ -2880,11 +2882,11 @@ namespace hud
             if(inventoryhealth)
             {
                 float fade = blend*inventoryhealthblend;
-                int heal = m_health(game::gamemode, game::mutators, game::focus->actortype);
-                float pulse = inventoryhealthflash ? clamp((heal-game::focus->health)/float(heal), 0.f, 1.f) : 0.f,
+                int full_health = m_health(game::gamemode, game::mutators, game::focus->actortype);
+                float pulse = inventoryhealthflash ? clamp((full_health-game::focus->health)/float(full_health), 0.f, 1.f) : 0.f,
                       throb = inventoryhealththrob > 0 && regentime && game::focus->lastregen && lastmillis-game::focus->lastregen <= regentime ? clamp((lastmillis-game::focus->lastregen)/float(regentime), 0.f, 1.f) : -1.f;
                 if(inventoryhealth&2)
-                    sy += drawbar(x, y, s, size, 1, inventoryhealthbartop, inventoryhealthbarbottom, fade, clamp(game::focus->health/float(heal), 0.f, 1.f), healthtex, healthbgtex, inventorytone, inventoryhealthbgglow, inventoryhealthbgblend, pulse, throb, inventoryhealththrob, inventoryhealthflash >= 2 ? (game::focus->lastregenamt <= 0 ? 0xFF0000 : 0x00FF00) : -1, game::focus->lastregenamt <= 0);
+                    sy += drawbar(x, y, s, size, 1, inventoryhealthbartop, inventoryhealthbarbottom, fade, clamp(game::focus->health/float(full_health), 0.f, 1.f), healthtex, healthbgtex, inventorytone, inventoryhealthbgglow, inventoryhealthbgblend, pulse, throb, inventoryhealththrob, inventoryhealthflash >= 2 ? (game::focus->lastregenamt <= 0 ? 0xFF0000 : 0x00FF00) : -1, game::focus->lastregenamt <= 0);
                 if(inventoryhealth&1)
                 {
                     float gr = 1, gg = 1, gb = 1;

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1763,13 +1763,15 @@ namespace hud
             glDisable(GL_BLEND);
         }
         if(progressing || (commandmillis <= 0 && !curcompass)) UI::render();
-        if(!progressing)
+
+        int pointertype = choose_pointer_type();
+        if(!progressing && pointertype != POINTER_NONE)
         {
             hudmatrix.ortho(0, hudwidth, hudheight, 0, -1, 1);
             flushhudmatrix();
             glEnable(GL_BLEND);
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            draw_pointer(hudwidth, hudheight, choose_pointer_type());
+            draw_pointer(hudwidth, hudheight, pointertype);
             glDisable(GL_BLEND);
         }
     }


### PR DESCRIPTION
The mouse cursor and the crosshair are currently treated as the same thing. The same variables are used to store their state and the same functions are used to render them. This was unexpected to me when I found it while trying to make changes to the mouse cursor.

In this pull request they are two different things. This makes it possible to e.g. show the crosshair and cursor in different positions at the same time and therefore it's also possible to keep the crosshair in the background while showing menus.