### PR TITLE
Add Colorscheme Options

### DIFF
--- a/config/colorschemes.cfg
+++ b/config/colorschemes.cfg
@@ -1,0 +1,55 @@
+colorscheme_default = [
+    resetvar ui_blend_background
+    resetvar ui_blend_slider
+    resetvar ui_blend_slider_border
+    resetvar ui_blend_textfield_background
+    resetvar ui_blend_textfield_border
+    resetvar ui_color_active
+    resetvar ui_color_background
+    resetvar ui_color_border
+    resetvar ui_color_checkbox
+    resetvar ui_color_hover
+    resetvar ui_color_radiobutton_box
+    resetvar ui_color_slider
+    resetvar ui_color_slider_border
+    resetvar ui_color_slider_mark
+    resetvar ui_color_slider_mark_border
+    resetvar ui_color_textfield_active
+    resetvar ui_color_textfield_background
+    resetvar ui_color_textfield_border
+    resetvar ui_color_tooltip
+    resetvar ui_color_tooltip_border
+]
+
+colorscheme_bluenebula_experimental = [
+    ui_blend_background 0.95
+    ui_blend_slider 0.5
+    ui_blend_slider_border 0.9
+    ui_blend_textfield_background 0.5
+    ui_blend_textfield_border 0.75
+    ui_color_active 0x1B60A8
+    ui_color_background 0x050505
+    ui_color_border 0x195A9E
+    ui_color_checkbox 0x4FD93D
+    ui_color_hover 0x65ACE7
+    ui_color_radiobutton_box 0x1B60A8
+    ui_color_slider 0x050505
+    ui_color_slider_border 0x65ACE7
+    ui_color_slider_mark 0x1B60A8
+    ui_color_slider_mark_border 0x0D4178
+    ui_color_textfield_active 0x1B60A8
+    ui_color_textfield_background 0x080808
+    ui_color_textfield_border 0x195A9E
+    ui_color_tooltip 0x080808
+    ui_color_tooltip_border 0x0D4178
+]
+
+setcolors = [
+    cases $arg1 "default" [
+        colorscheme_default
+    ] "bluenebula_experimental" [
+        colorscheme_bluenebula_experimental
+    ]
+]
+setcomplete setcolors 1
+setdesc setcolors "set colorscheme, options: default, bluenebula_experimental"

--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -280,8 +280,8 @@ options_menus_general = [
     ui_text "Customize Colors of GUI and Skin Elements:"
     ui_strut 0.5
     ui_loop_split i 3 (getvarinfo -1 1 0 256 128 "gui") [ // all hex colour vars matching gui
-        scurvar = (getvarinfo $i 1 0 256 128 "gui")
-        s = (stringreplace (stringreplace $scurvar "gui" "") "colour" "")
+        scurvar = (getvarinfo $i 1 0 256 128 "ui_")
+        s = (stringreplace (stringreplace $scurvar "ui_" "") "color_" "")
         ui_button $s [pick_color @scurvar] [] $modeeditingtex $$scurvar
     ] [ui_strut 5]
     ui_strut 1.5
@@ -303,6 +303,19 @@ options_menus_general = [
         ]
     ]
     ui_strut 0.5
+    
+    ui_font "super" [
+        ui_text "Set Colorscheme"
+    ]
+    ui_bar 6 0 0xFFFFFF; ui_strut 0.5
+
+    ui_font "super" [
+        ui_list [
+            ui_button "^frDefault" [ setcolors default ]; ui_strut 3
+            ui_button "^fbBlue Nebula Experimental" [ setcolors bluenebula_experimental ]
+        ]
+    ]
+
     // TOOLTIPS for Menu Options
     ui_font "little" [
         cases $guirollovername "show menu tooltips" [


### PR DESCRIPTION
This PR adds the option to choose between 2 colorschemes, one of them being the default red eclipse colorscheme and the other being an experimental blue nebula colorscheme I created, this is mainly to provide an easy way for users to try out colorschemes and give feedback
![2020-09-13-204904_1680x1050_scrot](https://user-images.githubusercontent.com/37220464/93026022-25ef5c80-f603-11ea-9c87-472dddcf7026.png)
