### PR TITLE
Show forced mutators with checkboxes

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -97,7 +97,7 @@ mutsvar = [
         s = $$arg5
         if (< $g 0) [ ui_no_hit_fx [ ui_button $arg1 [ disabled = @arg4 ] [] "checkdisable" 0x808080 ] ] [
             if (|| (& (mutsimplied $g $m) $arg4) (& $mutslockforce $arg4)) [
-                ui_button $arg1 [ implied = @arg4 ] [] "checkbox"
+                ui_button $arg1 [ implied = @arg4 ] [] "checkbox" 0xFFFFFF 0xFFFFFF -1 1 "checkboxon" $ui_color_checkbox_two
             ] [
                 if (ismodelocked $g (| $m $arg4) $arg4 $s) [ ui_no_hit_fx [ ui_button $arg1 [ disabled = @arg4 ] [] "checkdisable" 0x808080 ] ] [
                     t = (& $m $arg4)


### PR DESCRIPTION
With this commit the locked mutator checkboxes will be checked and impossible to uncheck.

Fixes #199 