### PR TITLE
Fix vanity radiobutton issue

### DIFF
--- a/config/menus/profile.cfg
+++ b/config/menus/profile.cfg
@@ -322,7 +322,7 @@ new_ui profile [
                                 ui_radiobutton $t vantypesel $i [
                                     vansel = -1
                                     loop j (getvanity) [
-                                        if (= (getvanity $j 0) @i) [
+                                        if (= (getvanity $j 0) @@i) [
                                             if (< -1 (indexof  $playerprevvanity (getvanity $j 1))) [vansel = $j]
                                         ]
                                     ]


### PR DESCRIPTION
This fixes an issue where the radiobuttons on the right side were not selected correctly when clicking one on the left side; they would always be on "nothing" even if you have something.