### PR TITLE
Replace custom bin suffix handling with CMake built-in variable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,24 +77,27 @@ endif()
 set(OpenGL_GL_PREFERENCE LEGACY)
 find_package(OpenGL REQUIRED)
 
+# import enet
+# note that we have to include this before setting CMAKE_EXECUTABLE_SUFFIX
+# otherwise, enet's platform tests fail with cryptic error messages
+set(ENET_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/enet)
+add_subdirectory(${ENET_SOURCE_DIRECTORY})
+
 # platform specific code
+# the binary suffix is appended to all executables' filenames
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(BIN_SUFFIX "_linux")
+    set(CMAKE_EXECUTABLE_SUFFIX "_linux")
 elseif(APPLE)
-    set(BIN_SUFFIX "_osx")
+    set(CMAKE_EXECUTABLE_SUFFIX "_osx")
 
     # TODO: fix genkey on macOS
     set(BUILD_GENKEY OFF)
 elseif(MINGW)
-    set(BIN_SUFFIX "_windows")
+    set(CMAKE_EXECUTABLE_SUFFIX "_windows")
 else()
     message(WARNING "Unknown build platform")
-    set(BIN_SUFFIX "_unknown")
+    set(CMAKE_EXECUTABLE_SUFFIX "_unknown")
 endif()
-
-# import enet
-set(ENET_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/enet)
-add_subdirectory(${ENET_SOURCE_DIRECTORY})
 
 # configure local includes
 include_directories(

--- a/src/cmake/build_client.cmake
+++ b/src/cmake/build_client.cmake
@@ -138,11 +138,11 @@ if(BUILD_CLIENT)
     endif()
 
     # finally, add the executable build configuration
-    add_blue_nebula_executable(${APPNAME}${BIN_SUFFIX} ${client_sources})
+    add_blue_nebula_executable(${APPNAME} ${client_sources})
 
     # CMake will also configure include dirs etc. for all targets linked against with target_link_libraries
-    target_link_libraries(${APPNAME}${BIN_SUFFIX} ${client_deps})
+    target_link_libraries(${APPNAME} ${client_deps})
 
     # make sure .rc file is added
-    add_windows_rc_file(${APPNAME}${BIN_SUFFIX})
+    add_windows_rc_file(${APPNAME})
 endif()

--- a/src/cmake/build_genkey.cmake
+++ b/src/cmake/build_genkey.cmake
@@ -19,12 +19,12 @@ if(BUILD_GENKEY)
         shared/crypto.cpp
     )
 
-    add_blue_nebula_executable(genkey${BIN_SUFFIX} ${genkey_sources})
+    add_blue_nebula_executable(genkey ${genkey_sources})
 
-    target_link_libraries(genkey${BIN_SUFFIX} ZLIB::ZLIB)
+    target_link_libraries(genkey ZLIB::ZLIB)
 
     # like for the server, we also have to define STANDALONE here to avoid dependencies on SDL2
-    set_target_properties(genkey${BIN_SUFFIX} PROPERTIES
+    set_target_properties(genkey PROPERTIES
         COMPILE_FLAGS "-DSTANDALONE"
     )
 endif()

--- a/src/cmake/build_server.cmake
+++ b/src/cmake/build_server.cmake
@@ -61,16 +61,16 @@ if(BUILD_SERVER)
     endif()
 
     # add the server executable and link it to enet
-    add_blue_nebula_executable(${APPNAME}_server${BIN_SUFFIX} ${server_sources})
+    add_blue_nebula_executable(${APPNAME}_server ${server_sources})
 
     # server only depends on enet
-    target_link_libraries(${APPNAME}_server${BIN_SUFFIX} ${server_deps})
+    target_link_libraries(${APPNAME}_server ${server_deps})
 
     # (define STANDALONE to "notify" the preprocessor that the server is built this time)
-    set_target_properties(${APPNAME}_server${BIN_SUFFIX} PROPERTIES
+    set_target_properties(${APPNAME}_server PROPERTIES
         COMPILE_FLAGS "-DSTANDALONE"
     )
 
     # make sure .rc file is added
-    add_windows_rc_file(${APPNAME}_server${BIN_SUFFIX})
+    add_windows_rc_file(${APPNAME}_server)
 endif()

--- a/src/install/nix/blue-nebula.desktop.am
+++ b/src/install/nix/blue-nebula.desktop.am
@@ -18,6 +18,6 @@ Comment[pt]=Jogo de tiros em primeira pessoa com jogabilidade ágil e editor inc
 Comment[sv]=Förstapersonsskjutare med rörlig spelstil och inbyggd baneditor
 Comment[fr]=Jeu de tir à la première personne avec un éditeur de cartes intégré
 Icon=@APPNAME@
-Exec=@APPNAME@@BIN_SUFFIX@
+Exec=@APPNAME@@CMAKE_EXECUTABLE_SUFFIX@
 Categories=Game;ActionGame;
 Keywords=fps,action,multiplayer,play,arena,mapeditor


### PR DESCRIPTION
Obviously, using `CMAKE_EXECUTABLE_SUFFIX` is better, as we don't have to curry the binary suffix whenever we want to run a command on a target.