### PR TITLE
Switch to Libera.Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The builds are, as of yet, **fully compatible with Red Eclipse 1.5.8 to 1.6.0**.
 
 ## Get in touch
 
-This project is still very young. We provide an official chatroom on the [freenode IRC network](https://freenode.net/). Our channel is [`#blue-nebula`](irc://chat.freenode.net/blue-nebula) ([webchat](https://webchat.freenode.net/#blue-nebula)).
+This project is still very young. We provide an official chatroom on the [Libera.Chat IRC network](https://libera.chat/). Our channel is [`#blue-nebula`](ircs://irc.libera.chat/blue-nebula).
 Please do not hesitate to get in touch with us!
 
 

--- a/config/menus/help.cfg
+++ b/config/menus/help.cfg
@@ -85,7 +85,7 @@ livesupport = 0
 new_ui support [
     ui_header "live support"
     if $livesupport [
-        ircgui freenode
+        ircgui liberachat
     ] [
         ui_font "emphasis" [ ui_center [ ui_text "ONLINE LIVE SUPPORT" ] ]
         ui_strut 0.5
@@ -99,7 +99,7 @@ new_ui support [
         ui_center [ ui_text "Are you sure you wish to continue?" ]
         ui_strut 0.5
         ui_center [ ui_stay_open [
-            ui_button "^fgYES, continue" [livesupport = 1; ircaddclient freenode irc.freenode.net 6667 (getplayername); ircaddchan freenode #blue-nebula ]
+            ui_button "^fgYES, continue" [livesupport = 1; ircaddclient liberachat irc.libera.chat 6667 (getplayername); ircaddchan liberachat #blue-nebula ]
             ui_spring 1
             ui_button "^foNO, go back" [clear_ui 1]
         ] ]

--- a/config/tips.cfg
+++ b/config/tips.cfg
@@ -24,8 +24,8 @@ resettips = [
     addtip "press ^fs^fw^f{=show_ui team}^fS to ^fs^fychange teams^fS"
     addtip "when you're ^fs^foon fire^fS you can ^fs^fcjump in water^fS to put yourself out, crouch if necessary"
     addtip "you're ^fs^fyless accurate^fS when ^fs^fyjumping^fS and ^fs^fymoving^fS, stop for a perfect shot"
-    addtip "you can chat with the community and developers in ^fs^fc#blue-nebula^fS on ^fs^fcchat.freenode.net^fS"
-    addtip "share your own tips with the developers in ^fs^fc#blue-nebula^fS on ^fs^fcchat.freenode.net^fS"
+    addtip "you can chat with the community and developers in ^fs^fc#blue-nebula^fS on ^fs^fcirc.libera.chat^fS"
+    addtip "share your own tips with the developers in ^fs^fc#blue-nebula^fS on ^fs^fcirc.libera.chat^fS"
     addtip "tips are ^fs^fccool^fS, you should ^fs^fyread them more often^fS"
 ]
 

--- a/doc/irc.txt
+++ b/doc/irc.txt
@@ -1,7 +1,7 @@
 = Blue Nebula IRC Channel =
 
 The Blue Nebula IRC (Internet Relay Chat) channel is located in #blue-nebula on
-the Freenode Network (chat.freenode.net). If you don't have an IRC client
+the Libera.Chat Network (irc.libera.chat). If you don't have an IRC client
 installed, you may access the channel from your web browser at
 https://go.blue-nebula.org/irc-chat
 


### PR DESCRIPTION
We decided to move away from freenode in the wake of the recent events. This commit updates relevant docs as well as the in-game tips and the built-in IRC chat client to use the new channel on Libera.Chat.