### PR TITLE
Update nix CI to Ubuntu bionic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ env:
 
 jobs:
   build-nix:
-    name: Ubuntu xenial (x86_64) debug
-    runs-on: ubuntu-16.04
+    name: Ubuntu bionic (x86_64) debug
+    runs-on: ubuntu-18.04
     env:
       BUILD_TYPE: Debug
     steps:
@@ -21,8 +21,8 @@ jobs:
         run: bash -xe ci/build-nix.sh
 
   build-nix-release:
-    name: Ubuntu xenial (x86_64) release
-    runs-on: ubuntu-16.04
+    name: Ubuntu bionic (x86_64) release
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Checkout enet submodule


### PR DESCRIPTION
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

It do be dead nao
