### PR TITLE
cmake: Update CMAKE_EXECUTABLE_SUFFIX for MINGW

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,7 +93,7 @@ elseif(APPLE)
     # TODO: fix genkey on macOS
     set(BUILD_GENKEY OFF)
 elseif(MINGW)
-    set(CMAKE_EXECUTABLE_SUFFIX "_windows")
+    set(CMAKE_EXECUTABLE_SUFFIX "_windows.exe")
 else()
     message(WARNING "Unknown build platform")
     set(CMAKE_EXECUTABLE_SUFFIX "_unknown")


### PR DESCRIPTION
When compiling for Windows (through MINGW or not), executables absolutely
require the "exe" file extension: CMAKE_EXECUTABLE_SUFFIX, which was
supposed to handle that extension in the file name was overridden on our
end, meaning that generated binaries were similar to *nix in that they have
no extension.

This, in turn, made "make install" and similar fail on this platform.

Strangely enough, this issue was not noticed until our CI was recently
updated to Ubuntu focal.

Link: https://cmake.org/cmake/help/latest/variable/CMAKE_EXECUTABLE_SUFFIX.html
