### PR TITLE
Prevent enet 1.3.18 from installing its include and static files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 if(CMAKE_BUILD_TYPE MATCHES RELEASE)
     message(STATUS "Release build detected, adding release flags")
-    set(COMMON_C_FLAGS "${CMAKE_C_FLAGS} -O2 -fomit-frame-pointer -fstack-protector-all -fpic -fpie -D_FORTIFY_SOURCE=3")
+    set(COMMON_C_FLAGS "${CMAKE_C_FLAGS} -O2 -fomit-frame-pointer -fstack-protector-all -fpic -fpie -D_FORTIFY_SOURCE=2")
     if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         set(COMMON_C_FLAGS "${ADDITIONAL_BUILD_FLAGS} -D_GLIBCXX_ASSERTIONS")
     endif()


### PR DESCRIPTION
Since updating enet to 1.3.18 a few days ago, it has started installing its include and static files with the game (`/include/enet` and `/lib/static/libenet.a`) probably due to the addition of [these lines](https://github.com/lsalzman/enet/blob/v1.3.18/CMakeLists.txt#L96) in enet 1.3.18 cmakelists file.

I'll admit that I'm not very experienced with cmake so please check if this is correct, but from what I understand, adding `EXCLUDE_FROM_ALL` after `add_subdirectory(${ENET_SOURCE_DIRECTORY}` should prevent enet from installing its files but still make it build and statically link with the game.

Since we use strong hardening flags, I thought it makes sense to switch to -D_FORTIFY_SOURCE=3, which is also more aligned with modern distros. However, note that it requires relatively recent compiler versions from about 2022. So if you're interested in being able to build the game on older compilers, we should probably stay on -D_FORTIFY_SOURCE=2.