### PR TITLE
Maintain Dockerfile and actions workflows with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Will automatically open PRs to update actions we use in the workflows (mainly useful for GitHub-provided stuff) as well as the Dockerfile (i.e., allowing us to regularly build updated images).